### PR TITLE
Enable resize for move-only types

### DIFF
--- a/src/lib/ankerl/svector.h
+++ b/src/lib/ankerl/svector.h
@@ -633,7 +633,14 @@ public:
     }
 
     void resize(size_t count) {
-        resize(count, T());
+        if (count > capacity()) {
+            reserve(count);
+        }
+        if (is_direct()) {
+            resize_after_reserve<direction::direct>(count);
+        } else {
+            resize_after_reserve<direction::indirect>(count);
+        }
     }
 
     void resize(size_t count, T const& value) {


### PR DESCRIPTION
This changes the implementation such that `svector<T>::resize(count)` can be used even if `T` is move-only.