### PR TITLE
Add emplace_back_unchecked

### DIFF
--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -692,6 +692,23 @@ public:
     [[nodiscard]] auto data() const -> T const* {
         return const_cast<svector*>(this)->data(); // NOLINT(cppcoreguidelines-pro-type-const-cast)
     }
+    
+    // Danger: only use when you know size() < capacity() ahead of time
+    template <class... Args>
+    auto emplace_back_unchecked(Args&&... args) -> T& {
+        T* ptr; // NOLINT(cppcoreguidelines-init-variables)
+        size_t s; // NOLINT(cppcoreguidelines-init-variables)
+        if (is_dir) {
+            s = size<direction::direct>();
+            ptr = data<direction::direct>() + s;
+            set_size<direction::direct>(s + 1);
+        } else {
+            s = size<direction::indirect>();
+            ptr = data<direction::indirect>() + s;
+            set_size<direction::indirect>(s + 1);
+        }
+        return *new (static_cast<void*>(ptr)) T(std::forward<Args>(args)...);
+    }
 
     template <class... Args>
     auto emplace_back(Args&&... args) -> T& {


### PR DESCRIPTION
I don't expect this to be accepted, however I actually wrote a short paper on this a few years ago. I tend to add this utility and another for modifying the size to my own custom vectors to be able to get every last bit of performance where I can. You can get an easy 100% performance swing with this over emplace_back. 

Even better is actually this pattern:
```c
std::vector<char> a_pseudo_string;
a_pseudo_string.reserve(32);

char *danger_ptr = a_pseudo_string.data();
for (size_t i = 0; i < 32; i++) {
  danger_ptr[i] = i+32;
}
// an incredibly awkward use of assign
a_psudo_string.assign(danger_ptr, danger_ptr+32);
```

Where `assign` also can get an unchecked variation. Since the internals of `svector` already has
```c
    template <direction D>
    void set_size(size_t s) {
        if constexpr (D == direction::direct) {
            set_direct_and_size(s);
        } else {
            indirect()->size(s);
        }
    }
```
The second is already possible*.

Alternatively could be named `unchecked_emplace_back`.