### PR TITLE
Fix for clash with Windows "min" and "max" macros

### DIFF
--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -134,7 +134,7 @@ public:
 template <typename T>
 struct storage : public header {
     static constexpr auto alignment_of_t = std::alignment_of_v<T>;
-    static constexpr auto max_alignment = std::max(std::alignment_of_v<header>, std::alignment_of_v<T>);
+	static constexpr auto max_alignment = (std::max)(std::alignment_of_v<header>, std::alignment_of_v<T>);
     static constexpr auto offset_to_data = detail::round_up(sizeof(header), alignment_of_t);
     static_assert(max_alignment <= __STDCPP_DEFAULT_NEW_ALIGNMENT__);
 
@@ -164,7 +164,7 @@ struct storage : public header {
             throw std::bad_alloc();
         }
         mem += offset_to_data;
-        if (static_cast<uint64_t>(mem) > static_cast<uint64_t>(std::numeric_limits<std::ptrdiff_t>::max())) {
+		if (static_cast<uint64_t>(mem) > static_cast<uint64_t>((std::numeric_limits<std::ptrdiff_t>::max)())) {
             throw std::bad_alloc();
         }
 
@@ -317,7 +317,7 @@ class svector {
             // got an overflow, set capacity to max
             new_capacity = max_size();
         }
-        return std::min(new_capacity, max_size());
+		return (std::min)(new_capacity, max_size());
     }
 
     template <direction D>
@@ -846,7 +846,7 @@ public:
     }
 
     [[nodiscard]] static auto max_size() -> size_t {
-        return std::numeric_limits<std::ptrdiff_t>::max();
+		return (std::numeric_limits<std::ptrdiff_t>::max)();
     }
 
     void swap(svector& other) {


### PR DESCRIPTION
Greetings!

Due to Windows having "min" and "max" defined as macros a compile error occurs whenever Windows.h and svector.h headers are included together on that system.

It results in the following error:

`...svector.h:137: error: C2589: '(': illegal token on right side of '::'`

Here is the code to demonstrate the issue:

~~~c++
#include <Windows.h> // <-- The culprit right here!
#include <iostream>
#include "svector.h"

int main (int, char *[])
{
    ankerl::svector <int, 10> vector {1, 2, 3, 4, 5};
    for (int i : vector)
        std::cout << i << std::endl;
    return 0;
}
~~~

The changes proposed simpy add parentheses around statements with `std::min` and `std::max`. It appears to be the easiest and least intrusive solution, no need to do things like messing with `NOMINMAX` macro, for instance.

Further reading:

https://stackoverflow.com/questions/1394132/macro-and-member-function-conflict
https://learn.microsoft.com/en-us/windows/win32/multimedia/min
https://learn.microsoft.com/en-us/windows/win32/multimedia/max