### PR TITLE
add .natvis file for visualizing svector contents in visual studio debugger

### DIFF
--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -183,6 +183,8 @@ template <typename T, size_t MinInlineCapacity>
 class svector {
     static_assert(MinInlineCapacity <= 127, "sorry, can't have more than 127 direct elements");
     static constexpr auto N = detail::automatic_capacity<T>(MinInlineCapacity);
+    static constexpr auto alignment_of_t = std::alignment_of_v<T>;
+    static constexpr auto offset_to_indirect_data = detail::round_up(sizeof(detail::header), alignment_of_t);
 
     enum class direction { direct, indirect };
 

--- a/svector.natvis
+++ b/svector.natvis
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+	<Type Name="ankerl::v1_0_3::svector&lt;*&gt;">
+		<DisplayString>svector</DisplayString>
+		<Expand>
+			<!--<Synthetic Name="mode" Condition="(m_data[0] &amp; 1) == 1">
+				<DisplayString>direct mode</DisplayString>
+			</Synthetic>-->
+			<Item Name="size" Condition="(m_data[0] &amp; 1) == 1">m_data[0] &gt;&gt; 1</Item>
+			<ArrayItems Condition="(m_data[0] &amp; 1) == 1">
+				<Size>m_data[0] &gt;&gt; 1</Size>
+				<ValuePointer>(value_type*)((char*)&amp;m_data + alignment_of_t)</ValuePointer>
+			</ArrayItems>
+			<!--<Synthetic Name="mode" Condition="(m_data[0] &amp; 1) == 0">
+				<DisplayString>indirect mode</DisplayString>
+			</Synthetic>-->
+			<Item Name="size" Condition="(m_data[0] &amp; 1) == 0">(*(detail::header**)&amp;m_data)->m_size</Item>
+			<ArrayItems Condition="(m_data[0] &amp; 1) == 0">
+				<Size>(*(detail::header**)&amp;m_data)->m_size</Size>
+				<ValuePointer>(value_type*)((char*)(*(detail::header**)&amp;m_data) + offset_to_indirect_data)</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+</AutoVisualizer>


### PR DESCRIPTION
here is more information about these files:
https://learn.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects?view=vs-2022

feel free to move the file anywhere else.

there are two lines added in the code, which provide (static constexpr!) data necessary to the debugger, as it cannot execute functions.
