### PR TITLE
Add .natvis debugger visualizer (completes #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   - [Random Access](#random-access)
   - [Random Insert](#random-insert)
 - [Building \& Testing](#building--testing)
+- [Debugging in Visual Studio](#debugging-in-visual-studio)
 - [Disclaimer](#disclaimer)
 
 `ankerl::svector` is an `std::vector`-like container that can hold some elements on the stack without the need for any allocation.
@@ -114,6 +115,17 @@ meson setup builddir
 cd builddir
 meson test
 ```
+
+## Debugging in Visual Studio
+
+Because `svector` packs size, capacity and data into a single byte array, the Visual Studio debugger shows
+raw bytes instead of the elements. `svector.natvis` fixes this: it displays the size and the contents for
+both direct and indirect mode.
+
+To use it, either add the file to your Visual Studio project, or copy it into
+`%USERPROFILE%\Documents\Visual Studio 2022\Visualizers\` to have it applied to every project.
+See [Create custom views of C++ objects](https://learn.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects)
+for details.
 
 ## Disclaimer
 

--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -183,6 +183,8 @@ template <typename T, size_t MinInlineCapacity>
 class svector {
     static_assert(MinInlineCapacity <= 127, "sorry, can't have more than 127 direct elements");
     static constexpr auto N = detail::automatic_capacity<T>(MinInlineCapacity);
+    static constexpr auto alignment_of_t = std::alignment_of_v<T>;
+    static constexpr auto offset_to_indirect_data = detail::round_up(sizeof(detail::header), alignment_of_t);
 
     enum class direction { direct, indirect };
 

--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -183,6 +183,9 @@ template <typename T, size_t MinInlineCapacity>
 class svector {
     static_assert(MinInlineCapacity <= 127, "sorry, can't have more than 127 direct elements");
     static constexpr auto N = detail::automatic_capacity<T>(MinInlineCapacity);
+
+    // Only used by svector.natvis: the Visual Studio debugger can't evaluate functions, so it needs
+    // these offsets as data. Keep in sync with direct_data() and detail::storage<T>::offset_to_data.
     static constexpr auto alignment_of_t = std::alignment_of_v<T>;
     static constexpr auto offset_to_indirect_data = detail::round_up(sizeof(detail::header), alignment_of_t);
 

--- a/svector.natvis
+++ b/svector.natvis
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+	<Type Name="ankerl::v1_0_3::svector&lt;*&gt;">
+		<DisplayString>svector</DisplayString>
+		<Expand>
+			<!--<Synthetic Name="mode" Condition="(m_data[0] &amp; 1) == 1">
+				<DisplayString>direct mode</DisplayString>
+			</Synthetic>-->
+			<Item Name="size" Condition="(m_data[0] &amp; 1) == 1">m_data[0] &gt;&gt; 1</Item>
+			<ArrayItems Condition="(m_data[0] &amp; 1) == 1">
+				<Size>m_data[0] &gt;&gt; 1</Size>
+				<ValuePointer>(value_type*)((char*)&amp;m_data + alignment_of_t)</ValuePointer>
+			</ArrayItems>
+			<!--<Synthetic Name="mode" Condition="(m_data[0] &amp; 1) == 0">
+				<DisplayString>indirect mode</DisplayString>
+			</Synthetic>-->
+			<Item Name="size" Condition="(m_data[0] &amp; 1) == 0">(*(detail::header**)&amp;m_data)->m_size</Item>
+			<ArrayItems Condition="(m_data[0] &amp; 1) == 0">
+				<Size>(*(detail::header**)&amp;m_data)->m_size</Size>
+				<ValuePointer>(value_type*)((char*)(*(detail::header**)&amp;m_data) + offset_to_indirect_data)</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+</AutoVisualizer>

--- a/svector.natvis
+++ b/svector.natvis
@@ -1,19 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
-	<Type Name="ankerl::v1_0_3::svector&lt;*&gt;">
-		<DisplayString>svector</DisplayString>
+	<!--
+		Visualizer for ankerl::svector in the Visual Studio debugger, see
+		https://learn.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects
+
+		The namespace is wildcarded on purpose: svector lives in an inline namespace generated from
+		ANKERL_SVECTOR_VERSION_* (v1_0_3 at the time of writing), so matching it literally would
+		silently stop working on the next version bump.
+
+		alignment_of_t and offset_to_indirect_data are static constexpr members of svector that
+		exist purely for this file, because the debugger cannot evaluate functions.
+	-->
+	<Type Name="ankerl::*::svector&lt;*&gt;">
+		<!-- direct mode: lowest bit of m_data[0] is 1, the size is in the upper 7 bits -->
+		<DisplayString Condition="(m_data[0] &amp; 1) == 1">{{ size={m_data[0] &gt;&gt; 1} direct }}</DisplayString>
+		<!-- indirect mode: lowest bit is 0, m_data holds a pointer to detail::storage<T> -->
+		<DisplayString Condition="(m_data[0] &amp; 1) == 0">{{ size={(*(detail::header**)&amp;m_data)->m_size} indirect }}</DisplayString>
 		<Expand>
-			<!--<Synthetic Name="mode" Condition="(m_data[0] &amp; 1) == 1">
-				<DisplayString>direct mode</DisplayString>
-			</Synthetic>-->
 			<Item Name="size" Condition="(m_data[0] &amp; 1) == 1">m_data[0] &gt;&gt; 1</Item>
 			<ArrayItems Condition="(m_data[0] &amp; 1) == 1">
 				<Size>m_data[0] &gt;&gt; 1</Size>
 				<ValuePointer>(value_type*)((char*)&amp;m_data + alignment_of_t)</ValuePointer>
 			</ArrayItems>
-			<!--<Synthetic Name="mode" Condition="(m_data[0] &amp; 1) == 0">
-				<DisplayString>indirect mode</DisplayString>
-			</Synthetic>-->
 			<Item Name="size" Condition="(m_data[0] &amp; 1) == 0">(*(detail::header**)&amp;m_data)->m_size</Item>
 			<ArrayItems Condition="(m_data[0] &amp; 1) == 0">
 				<Size>(*(detail::header**)&amp;m_data)->m_size</Size>


### PR DESCRIPTION
Completes #55 by @malytomas. Their original commit is preserved as the first commit here (the PR has "allow edits from maintainers" off), so merging this closes #55 as merged.

## Review of the original

The logic is correct. I verified the offsets against the implementation:

- direct mode data at `m_data + alignof(T)` matches `direct_data()` (`svector.h:218`)
- `round_up(sizeof(header), alignof(T))` matches `detail::storage<T>::offset_to_data` (`svector.h:138`)

The two added `static constexpr` members compile cleanly under `-Wall -Wextra` and have no ABI or runtime impact.

## What this adds

**1. Version independence.** The type was matched as `ankerl::v1_0_3::svector<*>`, but that namespace is generated from `ANKERL_SVECTOR_VERSION_*`:

```c
#define ANKERL_SVECTOR_VERSION_PATCH 3
...
inline namespace ANKERL_SVECTOR_NAMESPACE {
```

So bumping the patch version to `1.0.4` would silently break the visualizer, with no build error to catch it. Now matched as `ankerl::*::svector<*>` — the same wildcard-in-namespace-position trick abseil's natvis uses for its `lts_*` namespace.

**2. Useful `DisplayString`.** It was the constant `"svector"`; now it shows the size and the mode, e.g. `{ size=3 direct }`, reusing expressions the `<Item>` entries already depend on.

**3. Cleanup + docs.** Removed the commented-out `<Synthetic>` blocks; added a note in `svector.h` that `alignment_of_t` / `offset_to_indirect_data` exist only for the natvis so they don't get cleaned up as dead code later; added a README section on how to install it.

## One thing I could not verify

I have no MSVC here, so **I could not confirm that the debugger actually resolves the `static constexpr` members** (`alignment_of_t`, `offset_to_indirect_data`) or `detail::header` from the PDB. That is the part worth a manual check before/after merging — @malytomas presumably confirmed it for the original.

Everything else is verified: XML is well-formed, `meson test` passes (`Ok: 2, Fail: 0`), lint is clean.

Depends on #56 for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)