### PR TITLE
Add resize_and_overwrite (reworked #53)

### DIFF
--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -928,57 +928,43 @@ public:
         return insert(pos, l.begin(), l.end());
     }
 
-    template< class Operation >
-    constexpr void resize_and_overwrite(size_t count, Operation op) {
-        auto direct = is_direct();
+    /**
+     * @brief Resizes to count elements, letting op initialize the new ones in place.
+     *
+     * Same contract as std::string::resize_and_overwrite, see
+     * https://en.cppreference.com/w/cpp/string/basic_string/resize_and_overwrite
+     *
+     * op is called as op(p, count) with p == data(), and returns the actual new size:
+     *  * p[0, min(count, size())) are the existing elements, readable and assignable.
+     *  * p[min(count, size()), count) is raw uninitialized storage. op has to construct
+     *    every element it wants to keep, e.g. with placement new.
+     *  * op returns r, which must be in [0, count]. Afterwards size() == r, so p[0, r)
+     *    must all be constructed objects when op returns.
+     *
+     * This skips the value-initialization that resize() would do, which is what makes it
+     * faster: for e.g. reading into an svector<char> the zero fill is pure overhead.
+     */
+    template <class Operation>
+    void resize_and_overwrite(size_t count, Operation op) {
+        // step 1: make room. This preserves the existing elements and may switch to indirect mode.
+        reserve(count);
 
-        auto   current_data = data<direction::direct>();
-        size_t current_size = size<direction::direct>();
-        size_t current_capacity = capacity<direction::direct>();
-
-        if (!direct) {
-            current_data = data<direction::indirect>();
-            current_size = size<direction::indirect>();
-            current_capacity = capacity<direction::indirect>();
+        auto const old_size = size();
+        if (count < old_size) {
+            // Shrinking: the tail is gone. Commit the smaller size *before* running op, so that
+            // if op throws, the destructor sees exactly the elements that are still alive.
+            std::destroy_n(data() + count, old_size - count);
+            set_size(count);
         }
 
-        auto new_data = current_data;
+        // step 2: op initializes [min(count, old_size), count) and tells us how much it kept.
+        // The stored size is still min(count, old_size) here, so an exception escaping op
+        // destroys the untouched prefix and leaks only what op itself constructed.
+        auto const new_size = std::move(op)(data(), count);
 
-        if (count <= current_size) {
-            // destroy the trailing elements?
-            std::destroy_n(new_data + count, current_size - count);
-        } else if (count > current_capacity) {
-            // put everything into indirect storage
-            auto new_capacity = calculate_new_capacity(count, current_capacity);
-            auto storage = detail::storage<T>::alloc(new_capacity);
-            // step 1: https://en.cppreference.com/w/cpp/string/basic_string/resize_and_overwrite
-            // count is strictly >= the current size, move the data over to the new allocation
-            uninitialized_move_and_destroy(current_data, storage->data(), current_size);
-
-            if (!direct) { // cleanup if the old storage was indirect
-                auto* storage_direct = indirect();
-                std::destroy_at(storage_direct);
-                ::operator delete(storage_direct);
-            }
-            // treat the newly allocated storage as part of this svector
-            set_indirect(storage);
-            new_data = storage->data();
-
-            // step 2 & 3: perform the target operation and reset the size
-            size_t new_size = op(new_data, current_size);
-            set_size<direction::indirect>(new_size);
-            return;
-        } else {
-            // should be ok to reuse the current data
-        }
-
-        // step 2 & 3: perform the target operation and reset the size
-        size_t new_size = op(new_data, current_size);
-        if (direct) {
-            set_size<direction::direct>(new_size);
-        } else {
-            set_size<direction::indirect>(new_size);
-        }
+        // step 3: commit. new_size <= count <= capacity() is a precondition, so in direct mode
+        // this can never overflow the 7 bit size field.
+        set_size(new_size);
     }
 
     auto erase(const_iterator pos) -> iterator {

--- a/test/meson.build
+++ b/test/meson.build
@@ -33,6 +33,7 @@ test_sources = [
     'unit/push_back.cpp',
     'unit/reserve.cpp',
     'unit/resize.cpp',
+    'unit/resize_and_overwrite.cpp',
     'unit/reverse_iterators.cpp',
     'unit/round_up.cpp',
     'unit/show_comparison.cpp',

--- a/test/unit/resize_and_overwrite.cpp
+++ b/test/unit/resize_and_overwrite.cpp
@@ -1,0 +1,252 @@
+#include <ankerl/svector.h>
+#include <app/Counter.h>
+
+#include <doctest.h>
+
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+// Constructs elements [from, to) in place, like op is supposed to do for the raw part of the range.
+void construct_range(Counter::Obj* p, size_t from, size_t to, Counter& counts) {
+    for (size_t i = from; i < to; ++i) {
+        // cast to void* so we don't pick the poisoned operator new(size_t, Counter::Obj*) overload
+        ::new (static_cast<void*>(p + i)) Counter::Obj(i, counts);
+    }
+}
+
+} // namespace
+
+TEST_CASE("resize_and_overwrite_op_receives_count") {
+    // op(p, n) must get n == count, exactly like std::string::resize_and_overwrite.
+    // Passing the old size instead leaves op unable to tell how much space it may write to.
+    auto a = ankerl::svector<char, 4>();
+    a.resize(3, 'x');
+
+    size_t seen = 0;
+    a.resize_and_overwrite(20, [&](char* p, size_t n) -> size_t {
+        seen = n;
+        for (size_t i = 3; i < n; ++i) {
+            p[i] = 'y';
+        }
+        return n;
+    });
+
+    REQUIRE(seen == 20);
+    REQUIRE(a.size() == 20);
+    REQUIRE(a[0] == 'x');
+    REQUIRE(a[2] == 'x');
+    REQUIRE(a[3] == 'y');
+    REQUIRE(a[19] == 'y');
+
+    // shrinking too: n is the requested count, not the old size
+    a.resize_and_overwrite(5, [&](char* /*p*/, size_t n) -> size_t {
+        seen = n;
+        return n;
+    });
+    REQUIRE(seen == 5);
+    REQUIRE(a.size() == 5);
+}
+
+TEST_CASE("resize_and_overwrite_grow_within_inline_capacity") {
+    auto a = ankerl::svector<char, 30>();
+    auto const inline_capacity = a.capacity();
+    a.resize(2, 'a');
+
+    a.resize_and_overwrite(10, [](char* p, size_t n) -> size_t {
+        for (size_t i = 2; i < n; ++i) {
+            p[i] = 'b';
+        }
+        return n;
+    });
+
+    REQUIRE(a.size() == 10);
+    REQUIRE(a.capacity() == inline_capacity); // no reallocation, still direct
+    REQUIRE(a[0] == 'a');
+    REQUIRE(a[9] == 'b');
+}
+
+TEST_CASE("resize_and_overwrite_grow_beyond_inline_capacity") {
+    auto a = ankerl::svector<int, 4>();
+    for (int i = 0; i < 3; ++i) {
+        a.push_back(i);
+    }
+
+    a.resize_and_overwrite(1000, [](int* p, size_t n) -> size_t {
+        for (size_t i = 3; i < n; ++i) {
+            p[i] = static_cast<int>(i);
+        }
+        return n;
+    });
+
+    REQUIRE(a.size() == 1000);
+    REQUIRE(a.capacity() >= 1000);
+    for (size_t i = 0; i < a.size(); ++i) {
+        REQUIRE(a[i] == static_cast<int>(i)); // the original 3 survived the reallocation
+    }
+}
+
+TEST_CASE("resize_and_overwrite_returns_less_than_count") {
+    auto a = ankerl::svector<char, 4>();
+    a.resize_and_overwrite(100, [](char* p, size_t /*n*/) -> size_t {
+        for (size_t i = 0; i < 7; ++i) {
+            p[i] = static_cast<char>('a' + i);
+        }
+        return 7; // only kept 7 of the 100 we asked for
+    });
+
+    REQUIRE(a.size() == 7);
+    REQUIRE(a[0] == 'a');
+    REQUIRE(a[6] == 'g');
+}
+
+TEST_CASE("resize_and_overwrite_to_zero_and_empty") {
+    auto a = ankerl::svector<char, 4>();
+    a.resize(10, 'x');
+
+    a.resize_and_overwrite(0, [](char* /*p*/, size_t n) -> size_t {
+        REQUIRE(n == 0);
+        return 0;
+    });
+    REQUIRE(a.empty());
+
+    // and on an already empty vector
+    a.resize_and_overwrite(0, [](char* /*p*/, size_t /*n*/) -> size_t {
+        return 0;
+    });
+    REQUIRE(a.empty());
+}
+
+TEST_CASE("resize_and_overwrite_nontrivial_grow") {
+    Counter counts;
+    {
+        auto a = ankerl::svector<Counter::Obj, 3>();
+        for (size_t i = 0; i < 2; ++i) {
+            a.emplace_back(i, counts);
+        }
+
+        a.resize_and_overwrite(50, [&](Counter::Obj* p, size_t n) -> size_t {
+            REQUIRE(n == 50);
+            REQUIRE(p[0].get() == 0); // existing elements are readable
+            REQUIRE(p[1].get() == 1);
+            construct_range(p, 2, n, counts);
+            return n;
+        });
+
+        REQUIRE(a.size() == 50);
+        for (size_t i = 0; i < a.size(); ++i) {
+            REQUIRE(a[i].get() == i);
+        }
+    }
+    counts.check_all_done(); // every constructed object destroyed exactly once
+}
+
+TEST_CASE("resize_and_overwrite_nontrivial_shrink") {
+    Counter counts;
+    {
+        auto a = ankerl::svector<Counter::Obj, 3>();
+        for (size_t i = 0; i < 30; ++i) {
+            a.emplace_back(i, counts);
+        }
+
+        a.resize_and_overwrite(4, [](Counter::Obj* p, size_t n) -> size_t {
+            REQUIRE(n == 4);
+            REQUIRE(p[3].get() == 3); // the surviving prefix is untouched
+            return n;
+        });
+
+        REQUIRE(a.size() == 4);
+        for (size_t i = 0; i < a.size(); ++i) {
+            REQUIRE(a[i].get() == i);
+        }
+    }
+    counts.check_all_done(); // the 26 dropped elements destroyed exactly once, not twice
+}
+
+TEST_CASE("resize_and_overwrite_throwing_op_while_shrinking") {
+    // The tail is destroyed before op runs. If the size were not committed first, the
+    // destructor would destroy those elements a second time.
+    Counter counts;
+    {
+        auto a = ankerl::svector<Counter::Obj, 3>();
+        for (size_t i = 0; i < 30; ++i) {
+            a.emplace_back(i, counts);
+        }
+
+        REQUIRE_THROWS_AS(a.resize_and_overwrite(4,
+                                                 [](Counter::Obj* /*p*/, size_t /*n*/) -> size_t {
+                                                     throw std::runtime_error("boom");
+                                                 }),
+                          std::runtime_error);
+
+        // the vector is still usable and holds exactly the elements that survived
+        REQUIRE(a.size() == 4);
+        for (size_t i = 0; i < a.size(); ++i) {
+            REQUIRE(a[i].get() == i);
+        }
+    }
+    counts.check_all_done();
+}
+
+TEST_CASE("resize_and_overwrite_throwing_op_while_growing") {
+    // op throws after we reallocated. Everything that existed before must still be alive
+    // and get destroyed exactly once.
+    Counter counts;
+    {
+        auto a = ankerl::svector<Counter::Obj, 3>();
+        for (size_t i = 0; i < 5; ++i) {
+            a.emplace_back(i, counts);
+        }
+
+        REQUIRE_THROWS_AS(a.resize_and_overwrite(500,
+                                                 [](Counter::Obj* /*p*/, size_t /*n*/) -> size_t {
+                                                     throw std::runtime_error("boom");
+                                                 }),
+                          std::runtime_error);
+
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.capacity() >= 500); // the reserve did happen
+        for (size_t i = 0; i < a.size(); ++i) {
+            REQUIRE(a[i].get() == i);
+        }
+    }
+    counts.check_all_done();
+}
+
+TEST_CASE("resize_and_overwrite_skips_initialization") {
+    // The whole point: unlike resize(), the new elements are not value initialized.
+    Counter counts;
+    {
+        auto a = ankerl::svector<Counter::Obj, 3>();
+        auto const before = counts.defaultCtor;
+
+        a.resize_and_overwrite(20, [&](Counter::Obj* p, size_t n) -> size_t {
+            construct_range(p, 0, n, counts);
+            return n;
+        });
+
+        // op constructed all 20 itself, the container default constructed none of them
+        REQUIRE(counts.defaultCtor == before);
+        REQUIRE(a.size() == 20);
+    }
+    counts.check_all_done();
+}
+
+TEST_CASE("resize_and_overwrite_matches_read_into_buffer_pattern") {
+    // typical use: size the buffer up, fill part of it, report how much was actually written
+    auto const source = std::string("hello world");
+
+    auto buf = ankerl::svector<char, 8>();
+    buf.resize_and_overwrite(source.size() + 100, [&](char* p, size_t n) -> size_t {
+        REQUIRE(n == source.size() + 100);
+        std::char_traits<char>::copy(p, source.data(), source.size());
+        return source.size();
+    });
+
+    REQUIRE(buf.size() == source.size());
+    REQUIRE(std::string(buf.begin(), buf.end()) == source);
+}


### PR DESCRIPTION
Reworks #53 by @Andersama. Their original commit is preserved as the first commit here, so merging this closes #53 as merged.

The idea is good and matches where the discussion in #49 landed. The implementation had three defects, all verified by running it.

## 1. `op` received the wrong number

`std::string::resize_and_overwrite(count, op)` calls `op(p, count)` — the **requested** size. The original called `op(p, current_size)` — the **old** size:

```
resize_and_overwrite(8) on a size-3 vector:
  libstdc++ std::string  ->  callback gets n=8
  #53 as submitted       ->  callback gets n=3
```

Same signature, different meaning, no diagnostic. A callback written against the cppreference example the PR cites as its guide would think it has 3 writable slots when it has 8. This is the defect that most needed fixing, since it is silent.

## 2. Double destruction if `op` throws while shrinking

The tail was destroyed via `destroy_n` but the stored size was left untouched while `op` ran, so `~svector()` destroyed those elements again:

```
ERROR: AddressSanitizer: attempting double-free
  #9  svector<std::string, 2>::destroy() svector.h:525
  #10 svector<std::string, 2>::~svector() svector.h:600
```

## 3. Full element leak if `op` throws while growing

Elements were moved into the new storage and `set_indirect` was called, but the size stayed 0 until after `op` returned, so an exception lost all of them: `Direct leak of 190 byte(s) in 5 object(s)`.

## The rework

`reserve()` first, commit the shrunken size *before* calling `op`, commit `op`'s result after. At every point where `op` can throw, the stored size describes exactly the live elements. This also makes it a lot shorter, since `reserve()` and the non-template `set_size()` already handle the direct/indirect split.

Also dropped `constexpr` — `svector` uses `reinterpret_cast`, `memcpy` and placement new, so it can never be constant-evaluated, and nothing else in the API claims it.

## Tests

New `test/unit/resize_and_overwrite.cpp`, 11 cases: the `op(p, count)` contract, growth within and past inline capacity, shrinking, returning less than `count`, resize to 0, non-trivial element types, that no value-initialization happens, and both throwing-`op` paths. `Counter` verifies every element is destroyed exactly once.

**5 of the 11 fail against the original implementation** (`n == 0` gets 10, `n == 50` gets 2, plus `ERROR at ~Counter(): got 2 objects still alive!` / SIGABRT), so they are real regression guards rather than decoration.

Full suite: `Ok: 2, Fail: 0`. Lint clean.

## Note on scope

`resize_and_overwrite` is `string`-only in C++23, so this is a non-standard extension to a vector either way — that part is your call. If it goes in, it should match the standard signature exactly, which it now does.

Depends on #56 for CI; this branch is based on the pre-fix main, so its checks will be red until that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)