### PR TITLE
Move by copying the whole buffer when that is safe

### DIFF
--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -497,29 +497,27 @@ class svector {
         set_size(s);
     }
 
-    /**
-     * @brief Whether do_move_assign() can relocate other by copying m_data wholesale. See issue #54.
-     *
-     * Everything that makes up an svector lives inside m_data: in indirect mode just the pointer,
-     * in direct mode the size byte and the elements themselves. So copying the array copies the
-     * whole vector, with no branch on the mode and no loop over the elements.
-     *
-     * Two things have to hold. The elements must survive being relocated bytewise, which is what
-     * trivially copyable buys: byte-relocating e.g. a libstdc++ std::string in its small string
-     * mode leaves its data pointer aimed at other's inline buffer, which dangles as soon as other
-     * is gone.
-     *
-     * And the object has to be small, because the copy always covers the full inline capacity and
-     * not just the used part. Sorting a std::vector of svector<int> holding two elements each:
-     * gcc 16 -O3 gains 31% at 24 bytes, 21% at 72 bytes, but loses 72% at 264; clang 22 gains
-     * 38% / 29% with the same crossover. Filling a std::vector by moving svectors into it is
-     * allocation bound and gains 15% on clang while costing up to 3% on gcc.
-     */
-    static constexpr bool relocate_by_copying_m_data =
-        std::is_trivially_copyable_v<T> && detail::size_of_svector<T>(MinInlineCapacity) <= 128U;
-
     // precondition: all uninitialized
     void do_move_assign(svector&& other) {
+        /**
+         * Everything that makes up an svector lives inside m_data: in indirect mode just the
+         * pointer, in direct mode the size byte and the elements themselves. So copying the array
+         * copies the whole vector, with no branch on the mode and no loop over the elements. See
+         * issue #54.
+         *
+         * Two things have to hold. The elements must survive being relocated bytewise, which is
+         * what trivially copyable buys: byte-relocating e.g. a libstdc++ std::string in its small
+         * string mode leaves its data pointer aimed at other's inline buffer, which dangles as
+         * soon as other is gone.
+         *
+         * And the object has to be small, because the copy always covers the full inline capacity
+         * and not just the used part. Sorting a std::vector of svector<int> holding two elements
+         * each: gcc 16 -O3 gains 31% at 24 bytes, 21% at 72 bytes, but loses 72% at 264; clang 22
+         * gains 38% / 29% with the same crossover. Filling a std::vector by moving svectors into
+         * it is allocation bound and gains 15% on clang while costing up to 3% on gcc.
+         */
+        constexpr auto relocate_by_copying_m_data = std::is_trivially_copyable_v<T> && sizeof(m_data) <= 128U;
+
         if constexpr (relocate_by_copying_m_data) {
             m_data = other.m_data;
         } else if (!other.is_direct()) {

--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -497,9 +497,32 @@ class svector {
         set_size(s);
     }
 
+    /**
+     * @brief Whether do_move_assign() can relocate other by copying m_data wholesale. See issue #54.
+     *
+     * Everything that makes up an svector lives inside m_data: in indirect mode just the pointer,
+     * in direct mode the size byte and the elements themselves. So copying the array copies the
+     * whole vector, with no branch on the mode and no loop over the elements.
+     *
+     * Two things have to hold. The elements must survive being relocated bytewise, which is what
+     * trivially copyable buys: byte-relocating e.g. a libstdc++ std::string in its small string
+     * mode leaves its data pointer aimed at other's inline buffer, which dangles as soon as other
+     * is gone.
+     *
+     * And the object has to be small, because the copy always covers the full inline capacity and
+     * not just the used part. Sorting a std::vector of svector<int> holding two elements each:
+     * gcc 16 -O3 gains 31% at 24 bytes, 21% at 72 bytes, but loses 72% at 264; clang 22 gains
+     * 38% / 29% with the same crossover. Filling a std::vector by moving svectors into it is
+     * allocation bound and gains 15% on clang while costing up to 3% on gcc.
+     */
+    static constexpr bool relocate_by_copying_m_data =
+        std::is_trivially_copyable_v<T> && detail::size_of_svector<T>(MinInlineCapacity) <= 128U;
+
     // precondition: all uninitialized
     void do_move_assign(svector&& other) {
-        if (!other.is_direct()) {
+        if constexpr (relocate_by_copying_m_data) {
+            m_data = other.m_data;
+        } else if (!other.is_direct()) {
             // take other's memory, even when empty
             set_indirect(other.indirect());
         } else {

--- a/test/meson.build
+++ b/test/meson.build
@@ -28,6 +28,7 @@ test_sources = [
     'unit/includes_only.cpp',
     'unit/insert.cpp',
     'unit/member_types.cpp',
+    'unit/move_relocation.cpp',
     'unit/n_eq_0.cpp',
     'unit/pop_back.cpp',
     'unit/push_back.cpp',

--- a/test/unit/move_relocation.cpp
+++ b/test/unit/move_relocation.cpp
@@ -34,15 +34,11 @@ public:
         : m_value(other.m_value)
         , m_ptr(&m_value) {}
 
+    // declaring a move constructor already suppresses both assignment operators, which is all the
+    // tests below need: they only ever construct and destroy
     SelfRef(SelfRef&& other) noexcept
         : m_value(other.m_value)
         , m_ptr(&m_value) {}
-
-    // no assignment operators, the tests below only ever construct and destroy
-    auto operator=(SelfRef const&) -> SelfRef& = delete;
-    auto operator=(SelfRef&&) -> SelfRef& = delete;
-
-    ~SelfRef() = default;
 
     // reads through the self pointer, so a byte relocated object reads the source's storage
     [[nodiscard]] auto get() const -> int {
@@ -56,17 +52,16 @@ public:
 
 static_assert(!std::is_trivially_copyable_v<SelfRef>, "otherwise this type tests nothing");
 
-// svector<int, 100> is far bigger than the cutoff below which the whole buffer is copied, so it
-// takes the element by element path even though int is trivially copyable.
-constexpr size_t big_inline_capacity = 100;
-
-} // namespace
-
-TEST_CASE("move_ctor_direct_trivial") {
-    auto a = ankerl::svector<int, 4>{1, 2, 3};
-    REQUIRE(a.capacity() >= a.size()); // still inline
+// Move constructs an inline {1, 2, 3} and checks that the elements arrive. data() has to change:
+// the source was inline, so its elements are relocated into the target's own buffer instead of an
+// allocation changing hands.
+template <typename Vec>
+void check_move_ctor_from_inline() {
+    auto a = Vec{1, 2, 3};
+    auto const* a_data = a.data();
 
     auto b = std::move(a);
+    REQUIRE(b.data() != a_data);
     REQUIRE(b.size() == 3);
     REQUIRE(b[0] == 1);
     REQUIRE(b[1] == 2);
@@ -74,16 +69,17 @@ TEST_CASE("move_ctor_direct_trivial") {
     REQUIRE(a.empty()); // NOLINT(hicpp-invalid-access-moved,bugprone-use-after-move)
 }
 
-TEST_CASE("move_ctor_direct_big_inline_capacity") {
-    // same as above but on the element by element path
-    auto a = ankerl::svector<int, big_inline_capacity>{1, 2, 3};
+} // namespace
 
-    auto b = std::move(a);
-    REQUIRE(b.size() == 3);
-    REQUIRE(b[0] == 1);
-    REQUIRE(b[1] == 2);
-    REQUIRE(b[2] == 3);
-    REQUIRE(a.empty()); // NOLINT(hicpp-invalid-access-moved,bugprone-use-after-move)
+TEST_CASE("move_ctor_direct_trivial") {
+    // small enough that the whole buffer is copied in one go
+    check_move_ctor_from_inline<ankerl::svector<int, 4>>();
+}
+
+TEST_CASE("move_ctor_direct_big_inline_capacity") {
+    // svector<int, 100> is far past the size cutoff, so this takes the element by element path
+    // even though int is trivially copyable
+    check_move_ctor_from_inline<ankerl::svector<int, 100>>();
 }
 
 TEST_CASE("move_ctor_indirect_steals_allocation") {
@@ -133,15 +129,13 @@ TEST_CASE("move_assign_all_four_mode_combinations") {
 }
 
 TEST_CASE("move_self_referencing_element") {
-    // The whole reason moving cannot always be a byte copy of the buffer: SelfRef has to be move
-    // constructed so it can fix up its pointer. A byte copy leaves it aimed at the source's
-    // inline buffer, which is gone as soon as the source is.
+    // SelfRef has to be move constructed so it can fix up its pointer, see above. The source goes
+    // out of scope before the checks, so a byte copy leaves the elements pointing at dead storage.
     auto b = ankerl::svector<SelfRef, 4>();
     {
         auto a = ankerl::svector<SelfRef, 4>();
         a.emplace_back(11);
         a.emplace_back(22);
-        REQUIRE(a.size() <= a.capacity()); // inline, so the elements really are relocated
 
         b = std::move(a);
     }
@@ -164,8 +158,7 @@ TEST_CASE("move_self_referencing_element_ctor") {
 }
 
 TEST_CASE("move_small_strings") {
-    // the real world instance of the above: libstdc++'s std::string keeps its data pointer aimed
-    // at its own internal buffer while the string is short
+    // the real world instance of SelfRef: a short libstdc++ std::string is self referencing too
     auto const short_string = std::string("short"); // no heap allocation
 
     auto b = ankerl::svector<std::string, 4>();

--- a/test/unit/move_relocation.cpp
+++ b/test/unit/move_relocation.cpp
@@ -1,0 +1,217 @@
+// Tests for https://github.com/martinus/svector/issues/54
+//
+// Moving an svector relocates whatever is in its inline buffer. For trivially copyable elements
+// that is a plain byte copy of the whole object, otherwise every element has to be move
+// constructed one by one. Both paths have to end up with the same observable result: the target
+// holds the elements, the source is left empty and usable, and nothing is leaked or destroyed
+// twice.
+
+#include <ankerl/svector.h>
+#include <app/Counter.h>
+
+#include <doctest.h>
+
+#include <cstddef>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+// Not relocatable by copying bytes: it holds a pointer to its own member, so a byte copy leaves
+// the copy pointing into the source. A libstdc++ std::string in its small string mode does
+// exactly this, this is just the same thing in miniature and without a heap allocation to hide it.
+class SelfRef {
+    int m_value;
+    int* m_ptr;
+
+public:
+    explicit SelfRef(int value)
+        : m_value(value)
+        , m_ptr(&m_value) {}
+
+    SelfRef(SelfRef const& other)
+        : m_value(other.m_value)
+        , m_ptr(&m_value) {}
+
+    SelfRef(SelfRef&& other) noexcept
+        : m_value(other.m_value)
+        , m_ptr(&m_value) {}
+
+    // no assignment operators, the tests below only ever construct and destroy
+    auto operator=(SelfRef const&) -> SelfRef& = delete;
+    auto operator=(SelfRef&&) -> SelfRef& = delete;
+
+    ~SelfRef() = default;
+
+    // reads through the self pointer, so a byte relocated object reads the source's storage
+    [[nodiscard]] auto get() const -> int {
+        return *m_ptr;
+    }
+
+    [[nodiscard]] auto points_to_itself() const -> bool {
+        return m_ptr == &m_value;
+    }
+};
+
+static_assert(!std::is_trivially_copyable_v<SelfRef>, "otherwise this type tests nothing");
+
+// svector<int, 100> is far bigger than the cutoff below which the whole buffer is copied, so it
+// takes the element by element path even though int is trivially copyable.
+constexpr size_t big_inline_capacity = 100;
+
+} // namespace
+
+TEST_CASE("move_ctor_direct_trivial") {
+    auto a = ankerl::svector<int, 4>{1, 2, 3};
+    REQUIRE(a.capacity() >= a.size()); // still inline
+
+    auto b = std::move(a);
+    REQUIRE(b.size() == 3);
+    REQUIRE(b[0] == 1);
+    REQUIRE(b[1] == 2);
+    REQUIRE(b[2] == 3);
+    REQUIRE(a.empty()); // NOLINT(hicpp-invalid-access-moved,bugprone-use-after-move)
+}
+
+TEST_CASE("move_ctor_direct_big_inline_capacity") {
+    // same as above but on the element by element path
+    auto a = ankerl::svector<int, big_inline_capacity>{1, 2, 3};
+
+    auto b = std::move(a);
+    REQUIRE(b.size() == 3);
+    REQUIRE(b[0] == 1);
+    REQUIRE(b[1] == 2);
+    REQUIRE(b[2] == 3);
+    REQUIRE(a.empty()); // NOLINT(hicpp-invalid-access-moved,bugprone-use-after-move)
+}
+
+TEST_CASE("move_ctor_indirect_steals_allocation") {
+    auto a = ankerl::svector<int, 4>();
+    for (int i = 0; i < 100; ++i) {
+        a.push_back(i);
+    }
+    auto const* ptr = a.data();
+
+    auto b = std::move(a);
+    REQUIRE(b.data() == ptr); // no copy, the allocation itself moved over
+    REQUIRE(b.size() == 100);
+    for (int i = 0; i < 100; ++i) {
+        REQUIRE(b[i] == i);
+    }
+    REQUIRE(a.empty()); // NOLINT(hicpp-invalid-access-moved,bugprone-use-after-move)
+}
+
+TEST_CASE("move_assign_all_four_mode_combinations") {
+    auto make = [](size_t count) -> ankerl::svector<int, 4> {
+        auto v = ankerl::svector<int, 4>();
+        for (size_t i = 0; i < count; ++i) {
+            v.push_back(static_cast<int>(i));
+        }
+        return v;
+    };
+
+    // small stays inline, large is heap allocated
+    for (auto target_count : {size_t{2}, size_t{100}}) {
+        for (auto source_count : {size_t{0}, size_t{3}, size_t{100}}) {
+            auto target = make(target_count);
+            auto source = make(source_count);
+
+            target = std::move(source);
+            REQUIRE(target.size() == source_count);
+            for (size_t i = 0; i < source_count; ++i) {
+                REQUIRE(target[i] == static_cast<int>(i));
+            }
+            REQUIRE(source.empty()); // NOLINT(hicpp-invalid-access-moved,bugprone-use-after-move)
+
+            // the moved from vector is empty but fully usable
+            source.push_back(42); // NOLINT(hicpp-invalid-access-moved,bugprone-use-after-move)
+            REQUIRE(source.size() == 1);
+            REQUIRE(source[0] == 42);
+        }
+    }
+}
+
+TEST_CASE("move_self_referencing_element") {
+    // The whole reason moving cannot always be a byte copy of the buffer: SelfRef has to be move
+    // constructed so it can fix up its pointer. A byte copy leaves it aimed at the source's
+    // inline buffer, which is gone as soon as the source is.
+    auto b = ankerl::svector<SelfRef, 4>();
+    {
+        auto a = ankerl::svector<SelfRef, 4>();
+        a.emplace_back(11);
+        a.emplace_back(22);
+        REQUIRE(a.size() <= a.capacity()); // inline, so the elements really are relocated
+
+        b = std::move(a);
+    }
+
+    REQUIRE(b.size() == 2);
+    REQUIRE(b[0].points_to_itself());
+    REQUIRE(b[1].points_to_itself());
+    REQUIRE(b[0].get() == 11);
+    REQUIRE(b[1].get() == 22);
+}
+
+TEST_CASE("move_self_referencing_element_ctor") {
+    auto a = ankerl::svector<SelfRef, 4>();
+    a.emplace_back(7);
+
+    auto b = std::move(a);
+    REQUIRE(b.size() == 1);
+    REQUIRE(b[0].points_to_itself());
+    REQUIRE(b[0].get() == 7);
+}
+
+TEST_CASE("move_small_strings") {
+    // the real world instance of the above: libstdc++'s std::string keeps its data pointer aimed
+    // at its own internal buffer while the string is short
+    auto const short_string = std::string("short"); // no heap allocation
+
+    auto b = ankerl::svector<std::string, 4>();
+    {
+        auto a = ankerl::svector<std::string, 4>();
+        a.push_back(short_string);
+        a.push_back(short_string);
+        b = std::move(a);
+    }
+
+    REQUIRE(b.size() == 2);
+    REQUIRE(b[0] == short_string);
+    REQUIRE(b[1] == short_string);
+}
+
+TEST_CASE("move_leaves_no_leaks") {
+    Counter counts;
+    {
+        auto a = ankerl::svector<Counter::Obj, 3>();
+        a.emplace_back(1, counts);
+        a.emplace_back(2, counts);
+
+        auto b = std::move(a); // direct
+        REQUIRE(b.size() == 2);
+
+        for (size_t i = 0; i < 100; ++i) {
+            b.emplace_back(i, counts);
+        }
+        auto c = std::move(b); // indirect
+        REQUIRE(c.size() == 102);
+
+        // move back into a moved from vector, and into itself
+        a = std::move(c); // NOLINT(hicpp-invalid-access-moved,bugprone-use-after-move)
+        REQUIRE(a.size() == 102);
+    }
+    counts.check_all_done();
+}
+
+TEST_CASE("move_empty") {
+    auto a = ankerl::svector<int, 4>();
+    auto b = std::move(a);
+    REQUIRE(b.empty());
+    REQUIRE(a.empty()); // NOLINT(hicpp-invalid-access-moved,bugprone-use-after-move)
+
+    auto c = ankerl::svector<SelfRef, 4>();
+    auto d = std::move(c);
+    REQUIRE(d.empty());
+    REQUIRE(c.empty()); // NOLINT(hicpp-invalid-access-moved,bugprone-use-after-move)
+}


### PR DESCRIPTION
Fixes #54.

@Yikai-Liao is right that `do_move_assign()` is doing more work than it needs to, and that copying `m_data` is the fast way. It just cannot be done unconditionally.

## What is safe about it

Everything an svector consists of lives inside `m_data`: in indirect mode only the pointer, in direct mode the size byte and the elements. Copying the array copies the whole vector, with no branch on the mode and no loop over the elements.

## What is not

Two conditions have to hold.

**The elements must survive being relocated bytewise.** `std::is_trivially_copyable_v<T>` is what buys that. Without it the suggested version is broken, and not subtly: a libstdc++ `std::string` in its small string mode keeps its data pointer aimed at its own internal buffer, so a byte copy leaves the moved-to string reading the moved-from svector's inline buffer.

```
src data ptr: 0x7fffebe89950, buffer at 0x7fffebe89940
dst data ptr: 0x7fffebe89950, buffer at 0x7fffebe89960   <- points into src
```

With the guard removed, `move_small_strings` aborts under asan with `stack-use-after-scope`, `move_self_referencing_element` fails outright, and the pre-existing `move_assignment` test aborts on `Counter::Obj`.

**The object has to be small.** The copy always covers the full inline capacity, not just the used part, so past a point it moves more bytes than the loop it replaces. Sorting a `std::vector` of `svector<int>` holding two elements each:

| sizeof | gcc 16 -O3 | clang 22 -O3 |
|---:|---:|---:|
| 24 | -31% | -38% |
| 40 | -25% | -33% |
| 72 | -21% | -29% |
| 264 | **+72%** | — |

Filling a `std::vector` by moving svectors into it is allocation bound, and there gcc pays up to 3% for the extra bytes at sizeof 72 while clang still gains 15% at sizeof 24. The cutoff is 128 bytes, which keeps every configuration svector is actually meant for.

Instruction count for a move drops from 604 to 253 per sorted element on gcc, branches from 158 to 71.

## Tests

New `test/unit/move_relocation.cpp`, 9 cases: both paths for the trivially copyable branch (`svector<int, 4>` takes the buffer copy, `svector<int, 100>` is over the cutoff and takes the element loop), all four direct/indirect combinations of move assignment, the moved-from vector being empty and reusable, and the two regression guards described above.

Verified green with gcc and clang under `-fsanitize=address,undefined`.