### PR TITLE
noexcept correctness: stop lying about moves, start promising the rest

### DIFF
--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -653,7 +653,7 @@ public:
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-    svector() {
+    svector() noexcept {
         set_direct_and_size(0);
     }
 
@@ -792,28 +792,28 @@ public:
         }
     }
 
-    [[nodiscard]] auto capacity() const -> size_t {
+    [[nodiscard]] auto capacity() const noexcept -> size_t {
         if (is_direct()) {
             return capacity<direction::direct>();
         }
         return capacity<direction::indirect>();
     }
 
-    [[nodiscard]] auto size() const -> size_t {
+    [[nodiscard]] auto size() const noexcept -> size_t {
         if (is_direct()) {
             return size<direction::direct>();
         }
         return size<direction::indirect>();
     }
 
-    [[nodiscard]] auto data() -> T* {
+    [[nodiscard]] auto data() noexcept -> T* {
         if (is_direct()) {
             return direct_data();
         }
         return indirect()->data();
     }
 
-    [[nodiscard]] auto data() const -> T const* {
+    [[nodiscard]] auto data() const noexcept -> T const* {
         return const_cast<svector*>(this)->data(); // NOLINT(cppcoreguidelines-pro-type-const-cast)
     }
 
@@ -850,11 +850,11 @@ public:
         emplace_back(std::move(value));
     }
 
-    [[nodiscard]] auto operator[](size_t idx) const -> T const& {
+    [[nodiscard]] auto operator[](size_t idx) const noexcept -> T const& {
         return *(data() + idx);
     }
 
-    [[nodiscard]] auto operator[](size_t idx) -> T& {
+    [[nodiscard]] auto operator[](size_t idx) noexcept -> T& {
         return *(data() + idx);
     }
 
@@ -869,77 +869,77 @@ public:
         return const_cast<svector*>(this)->at(idx); // NOLINT(cppcoreguidelines-pro-type-const-cast)
     }
 
-    [[nodiscard]] auto begin() const -> T const* {
+    [[nodiscard]] auto begin() const noexcept -> T const* {
         return data();
     }
 
-    [[nodiscard]] auto cbegin() const -> T const* {
+    [[nodiscard]] auto cbegin() const noexcept -> T const* {
         return begin();
     }
 
-    [[nodiscard]] auto begin() -> T* {
+    [[nodiscard]] auto begin() noexcept -> T* {
         return data();
     }
 
-    [[nodiscard]] auto end() -> T* {
+    [[nodiscard]] auto end() noexcept -> T* {
         if (is_direct()) {
             return data<direction::direct>() + size<direction::direct>();
         }
         return data<direction::indirect>() + size<direction::indirect>();
     }
 
-    [[nodiscard]] auto end() const -> T const* {
+    [[nodiscard]] auto end() const noexcept -> T const* {
         return const_cast<svector*>(this)->end(); // NOLINT(cppcoreguidelines-pro-type-const-cast)
     }
 
-    [[nodiscard]] auto cend() const -> T const* {
+    [[nodiscard]] auto cend() const noexcept -> T const* {
         return end();
     }
 
-    [[nodiscard]] auto rbegin() -> reverse_iterator {
+    [[nodiscard]] auto rbegin() noexcept -> reverse_iterator {
         return reverse_iterator{end()};
     }
 
-    [[nodiscard]] auto rbegin() const -> const_reverse_iterator {
+    [[nodiscard]] auto rbegin() const noexcept -> const_reverse_iterator {
         return crbegin();
     }
 
-    [[nodiscard]] auto crbegin() const -> const_reverse_iterator {
+    [[nodiscard]] auto crbegin() const noexcept -> const_reverse_iterator {
         return const_reverse_iterator{end()};
     }
 
-    [[nodiscard]] auto rend() -> reverse_iterator {
+    [[nodiscard]] auto rend() noexcept -> reverse_iterator {
         return reverse_iterator{begin()};
     }
 
-    [[nodiscard]] auto rend() const -> const_reverse_iterator {
+    [[nodiscard]] auto rend() const noexcept -> const_reverse_iterator {
         return crend();
     }
 
-    [[nodiscard]] auto crend() const -> const_reverse_iterator {
+    [[nodiscard]] auto crend() const noexcept -> const_reverse_iterator {
         return const_reverse_iterator{begin()};
     }
 
-    [[nodiscard]] auto front() const -> T const& {
+    [[nodiscard]] auto front() const noexcept -> T const& {
         return *data();
     }
 
-    [[nodiscard]] auto front() -> T& {
+    [[nodiscard]] auto front() noexcept -> T& {
         return *data();
     }
 
-    [[nodiscard]] auto back() -> T& {
+    [[nodiscard]] auto back() noexcept -> T& {
         if (is_direct()) {
             return *(data<direction::direct>() + size<direction::direct>() - 1);
         }
         return *(data<direction::indirect>() + size<direction::indirect>() - 1);
     }
 
-    [[nodiscard]] auto back() const -> T const& {
+    [[nodiscard]] auto back() const noexcept -> T const& {
         return const_cast<svector*>(this)->back(); // NOLINT(cppcoreguidelines-pro-type-const-cast)
     }
 
-    void clear() {
+    void clear() noexcept {
         if constexpr (!std::is_trivially_destructible_v<T>) {
             std::destroy(begin(), end());
         }
@@ -951,11 +951,11 @@ public:
         }
     }
 
-    [[nodiscard]] auto empty() const -> bool {
+    [[nodiscard]] auto empty() const noexcept -> bool {
         return 0U == size();
     }
 
-    void pop_back() {
+    void pop_back() noexcept {
         if (is_direct()) {
             pop_back<direction::direct>();
         } else {
@@ -963,11 +963,13 @@ public:
         }
     }
 
-    [[nodiscard]] static auto max_size() -> size_t {
+    [[nodiscard]] static auto max_size() noexcept -> size_t {
         return (std::numeric_limits<std::ptrdiff_t>::max)();
     }
 
-    void swap(svector& other) {
+    // std::swap does one move construction and two move assignments, so it inherits exactly
+    // the condition those carry
+    void swap(svector& other) noexcept(std::is_nothrow_move_constructible_v<T>) {
         // TODO we could try to do the minimum number of moves
         std::swap(*this, other);
     }

--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -284,15 +284,27 @@ class svector {
     /**
      * @brief Moves all current elements into storage, frees the old one and adopts storage.
      *
+     * Takes ownership of storage even when it fails: T's move constructor is allowed to throw,
+     * and then nothing here has happened yet, so storage has to be freed again on the way out or
+     * it leaks. num_constructed says how many elements the caller has already built at the end of
+     * storage, which then have to be destroyed too. std::uninitialized_move_n already cleans up
+     * whatever it managed to move itself.
+     *
      * Not a template, so every emplace_back instantiation shares this instead of inlining its
      * own copy of the direct/indirect fork.
      */
-    void take_over_storage(detail::storage<T>* storage, size_t new_size) {
-        if (is_direct()) {
-            uninitialized_move_and_destroy(data<direction::direct>(), storage->data(), size<direction::direct>());
-        } else {
-            uninitialized_move_and_destroy(data<direction::indirect>(), storage->data(), size<direction::indirect>());
-            detail::storage<T>::dealloc(indirect());
+    void take_over_storage(detail::storage<T>* storage, size_t new_size, size_t num_constructed = 0) {
+        try {
+            if (is_direct()) {
+                uninitialized_move_and_destroy(data<direction::direct>(), storage->data(), size<direction::direct>());
+            } else {
+                uninitialized_move_and_destroy(data<direction::indirect>(), storage->data(), size<direction::indirect>());
+                detail::storage<T>::dealloc(indirect());
+            }
+        } catch (...) {
+            std::destroy_n(storage->data() + new_size - num_constructed, num_constructed);
+            detail::storage<T>::dealloc(storage);
+            throw;
         }
         storage->size(new_size);
         set_indirect(storage);
@@ -322,8 +334,9 @@ class svector {
             throw;
         }
 
-        // args has been consumed, the old elements can be moved now
-        take_over_storage(storage, s + 1);
+        // args has been consumed, the old elements can be moved now. If that throws, element is
+        // the one thing already built in storage, so tell take_over_storage to clean it up.
+        take_over_storage(storage, s + 1, 1);
         return *element;
     }
 
@@ -673,7 +686,16 @@ public:
         set_size(s);
     }
 
-    svector(svector&& other) noexcept
+    /**
+     * @brief Moving is only noexcept when moving a T is.
+     *
+     * std::vector can promise this unconditionally because its move only steals a pointer. In
+     * direct mode we have to relocate the inline elements instead, which calls T's move
+     * constructor, so the promise is only ours to make when that one is noexcept. Claiming it
+     * anyway turns a throwing move into std::terminate, and makes std::move_if_noexcept pick us
+     * up for a move where it should have fallen back to a copy. See issue #63.
+     */
+    svector(svector&& other) noexcept(std::is_nothrow_move_constructible_v<T>)
         : svector() {
         do_move_assign(std::move(other));
     }
@@ -715,7 +737,8 @@ public:
         return *this;
     }
 
-    auto operator=(svector&& other) noexcept -> svector& {
+    // conditional for the same reason as the move constructor, see there
+    auto operator=(svector&& other) noexcept(std::is_nothrow_move_constructible_v<T>) -> svector& {
         if (&other == this) {
             // It doesn't seem to be required to do self-check, but let's do it anyways to be safe
             return *this;

--- a/test/meson.build
+++ b/test/meson.build
@@ -30,6 +30,7 @@ test_sources = [
     'unit/member_types.cpp',
     'unit/move_relocation.cpp',
     'unit/n_eq_0.cpp',
+    'unit/noexcept_contract.cpp',
     'unit/pop_back.cpp',
     'unit/push_back.cpp',
     'unit/reserve.cpp',

--- a/test/unit/noexcept_contract.cpp
+++ b/test/unit/noexcept_contract.cpp
@@ -1,0 +1,131 @@
+// Tests for https://github.com/martinus/svector/issues/63
+//
+// svector is meant to be a drop in for std::vector, so it should make the same noexcept promises
+// wherever it can, and no promise it cannot keep. The one place it genuinely differs is moving:
+// std::vector only ever steals a pointer, while an svector in direct mode has to relocate its
+// inline elements, which runs T's move constructor.
+
+#include <ankerl/svector.h>
+
+#include <doctest.h>
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+// Moving this throws, so no container holding it can promise a noexcept move.
+struct ThrowingMove {
+    int value;
+
+    explicit ThrowingMove(int v)
+        : value(v) {}
+
+    ThrowingMove(ThrowingMove const& other) = default;
+
+    ThrowingMove(ThrowingMove&& other) // NOLINT(performance-noexcept-move-constructor)
+        : value(other.value) {
+        if (value == throwing_value) {
+            throw std::runtime_error("move");
+        }
+    }
+
+    auto operator=(ThrowingMove const&) -> ThrowingMove& = default;
+    ~ThrowingMove() = default;
+
+    static constexpr int throwing_value = 42;
+};
+
+static_assert(!std::is_nothrow_move_constructible_v<ThrowingMove>);
+
+using SvString = ankerl::svector<std::string, 4>;
+using SvThrowing = ankerl::svector<ThrowingMove, 4>;
+
+} // namespace
+
+// A T that moves without throwing keeps the unconditional promise it had before.
+static_assert(std::is_nothrow_move_constructible_v<ankerl::svector<int, 4>>);
+static_assert(std::is_nothrow_move_assignable_v<ankerl::svector<int, 4>>);
+static_assert(std::is_nothrow_move_constructible_v<SvString>);
+static_assert(std::is_nothrow_move_assignable_v<SvString>);
+
+// A T that can throw while moving must not be covered up.
+static_assert(!std::is_nothrow_move_constructible_v<SvThrowing>);
+static_assert(!std::is_nothrow_move_assignable_v<SvThrowing>);
+
+TEST_CASE("noexcept_throwing_move_propagates") {
+    // Before the fix this called std::terminate instead of unwinding.
+    auto a = SvThrowing();
+    a.emplace_back(ThrowingMove::throwing_value);
+    REQUIRE(a.size() == 1);
+
+    REQUIRE_THROWS_AS(SvThrowing(std::move(a)), std::runtime_error);
+}
+
+TEST_CASE("noexcept_throwing_move_assign_propagates") {
+    auto a = SvThrowing();
+    a.emplace_back(ThrowingMove::throwing_value);
+
+    auto b = SvThrowing();
+    REQUIRE_THROWS_AS(b = std::move(a), std::runtime_error);
+}
+
+TEST_CASE("noexcept_indirect_move_never_touches_elements") {
+    // Once we are indirect the move only takes over the allocation, so even a throwing move
+    // constructor is never called. Only the compile time promise has to be conservative.
+    auto a = SvThrowing();
+    for (int i = 0; i < 100; ++i) {
+        a.emplace_back(i + 1000); // never the throwing value, growth has to relocate these
+    }
+    a.emplace_back(ThrowingMove::throwing_value); // would throw if it were ever moved
+    auto const* ptr = a.data();
+
+    auto b = std::move(a);
+    REQUIRE(b.data() == ptr);
+    REQUIRE(b.size() == 101);
+}
+
+TEST_CASE("growth_with_throwing_move_does_not_leak") {
+    // Growing relocates the existing elements into freshly allocated storage. When T's move
+    // constructor throws partway through, that storage was leaked: it is not owned by anything
+    // yet, and the element emplace_back had already built in it was never destroyed. Only
+    // reachable with a throwing move, which is why claiming an unconditional noexcept move hid
+    // it. Run under asan to see the leak.
+    auto v = SvThrowing();
+    while (v.size() < v.capacity()) {
+        v.emplace_back(0);
+    }
+    // one element that refuses to be relocated, then force a reallocation
+    v.emplace_back(ThrowingMove::throwing_value);
+    auto const size_before = v.size();
+    while (v.size() < v.capacity()) {
+        v.emplace_back(0);
+    }
+
+    REQUIRE_THROWS_AS(v.emplace_back(0), std::runtime_error);
+
+    // the failed grow left us alone, we still own everything we owned before
+    REQUIRE(v.size() >= size_before);
+    REQUIRE(v[size_before - 1].value == ThrowingMove::throwing_value);
+}
+
+TEST_CASE("noexcept_vector_growth_keeps_strong_guarantee") {
+    // std::vector picks move vs copy with std::move_if_noexcept. While svector claimed an
+    // unconditional noexcept move, growing a std::vector of them moved the elements and a
+    // throwing move terminated instead of rolling back.
+    auto outer = std::vector<SvThrowing>();
+    for (int i = 0; i < 8; ++i) {
+        outer.emplace_back();
+        outer.back().emplace_back(ThrowingMove::throwing_value);
+    }
+
+    for (int i = 0; i < 200; ++i) {
+        outer.emplace_back(); // reallocates repeatedly, must fall back to copying
+    }
+    REQUIRE(outer.size() == 208);
+    REQUIRE(outer[0][0].value == ThrowingMove::throwing_value);
+}

--- a/test/unit/noexcept_contract.cpp
+++ b/test/unit/noexcept_contract.cpp
@@ -57,6 +57,48 @@ static_assert(std::is_nothrow_move_assignable_v<SvString>);
 static_assert(!std::is_nothrow_move_constructible_v<SvThrowing>);
 static_assert(!std::is_nothrow_move_assignable_v<SvThrowing>);
 
+// swap is a move construction plus two move assignments, so it carries the same condition
+static_assert(std::is_nothrow_swappable_v<SvString>);
+static_assert(!std::is_nothrow_swappable_v<SvThrowing>);
+
+// Everything else either cannot throw at all or always can, independently of T. Those have to
+// agree with std::vector, otherwise svector is not a drop in replacement for code that asks.
+//
+// Only ever named inside noexcept(), which does not evaluate its operand, so these need no
+// definition.
+extern SvString sv;                  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+extern std::vector<std::string> vec; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+#define SAME_AS_STD_VECTOR(call) static_assert(noexcept(sv.call) == noexcept(vec.call), #call)
+
+static_assert(std::is_nothrow_default_constructible_v<SvString>);
+static_assert(std::is_nothrow_default_constructible_v<std::vector<std::string>>);
+
+SAME_AS_STD_VECTOR(size());
+SAME_AS_STD_VECTOR(capacity());
+SAME_AS_STD_VECTOR(empty());
+SAME_AS_STD_VECTOR(max_size());
+SAME_AS_STD_VECTOR(data());
+SAME_AS_STD_VECTOR(begin());
+SAME_AS_STD_VECTOR(end());
+SAME_AS_STD_VECTOR(cbegin());
+SAME_AS_STD_VECTOR(cend());
+SAME_AS_STD_VECTOR(rbegin());
+SAME_AS_STD_VECTOR(rend());
+SAME_AS_STD_VECTOR(crbegin());
+SAME_AS_STD_VECTOR(crend());
+SAME_AS_STD_VECTOR(operator[](0));
+SAME_AS_STD_VECTOR(front());
+SAME_AS_STD_VECTOR(back());
+SAME_AS_STD_VECTOR(clear());
+SAME_AS_STD_VECTOR(pop_back());
+
+// the two that legitimately can throw: at() checks the index, shrink_to_fit() allocates
+SAME_AS_STD_VECTOR(at(0));
+SAME_AS_STD_VECTOR(shrink_to_fit());
+
+#undef SAME_AS_STD_VECTOR
+
 TEST_CASE("noexcept_throwing_move_propagates") {
     // Before the fix this called std::terminate instead of unwinding.
     auto a = SvThrowing();

--- a/test/unit/noexcept_contract.cpp
+++ b/test/unit/noexcept_contract.cpp
@@ -57,47 +57,57 @@ static_assert(std::is_nothrow_move_assignable_v<SvString>);
 static_assert(!std::is_nothrow_move_constructible_v<SvThrowing>);
 static_assert(!std::is_nothrow_move_assignable_v<SvThrowing>);
 
-// swap is a move construction plus two move assignments, so it carries the same condition
+// swap is a move construction plus two move assignments, so it carries the same condition. This
+// is the one place where svector cannot match std::vector, whose swap is noexcept for any T
+// because it only exchanges pointers.
 static_assert(std::is_nothrow_swappable_v<SvString>);
 static_assert(!std::is_nothrow_swappable_v<SvThrowing>);
 
-// Everything else either cannot throw at all or always can, independently of T. Those have to
-// agree with std::vector, otherwise svector is not a drop in replacement for code that asks.
-//
 // Only ever named inside noexcept(), which does not evaluate its operand, so these need no
 // definition.
 extern SvString sv;                  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 extern std::vector<std::string> vec; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-#define SAME_AS_STD_VECTOR(call) static_assert(noexcept(sv.call) == noexcept(vec.call), #call)
+// [vector.overview] spells these out as noexcept, so every conforming std::vector agrees and
+// svector can be held to the same guarantee portably. Asserting it for std::vector too is what
+// makes this a check against the standard rather than against one implementation.
+#define STANDARD_REQUIRES_NOEXCEPT(call)     \
+    static_assert(noexcept(sv.call), #call); \
+    static_assert(noexcept(vec.call), #call)
 
 static_assert(std::is_nothrow_default_constructible_v<SvString>);
 static_assert(std::is_nothrow_default_constructible_v<std::vector<std::string>>);
 
-SAME_AS_STD_VECTOR(size());
-SAME_AS_STD_VECTOR(capacity());
-SAME_AS_STD_VECTOR(empty());
-SAME_AS_STD_VECTOR(max_size());
-SAME_AS_STD_VECTOR(data());
-SAME_AS_STD_VECTOR(begin());
-SAME_AS_STD_VECTOR(end());
-SAME_AS_STD_VECTOR(cbegin());
-SAME_AS_STD_VECTOR(cend());
-SAME_AS_STD_VECTOR(rbegin());
-SAME_AS_STD_VECTOR(rend());
-SAME_AS_STD_VECTOR(crbegin());
-SAME_AS_STD_VECTOR(crend());
-SAME_AS_STD_VECTOR(operator[](0));
-SAME_AS_STD_VECTOR(front());
-SAME_AS_STD_VECTOR(back());
-SAME_AS_STD_VECTOR(clear());
-SAME_AS_STD_VECTOR(pop_back());
+STANDARD_REQUIRES_NOEXCEPT(size());
+STANDARD_REQUIRES_NOEXCEPT(capacity());
+STANDARD_REQUIRES_NOEXCEPT(empty());
+STANDARD_REQUIRES_NOEXCEPT(max_size());
+STANDARD_REQUIRES_NOEXCEPT(data());
+STANDARD_REQUIRES_NOEXCEPT(begin());
+STANDARD_REQUIRES_NOEXCEPT(end());
+STANDARD_REQUIRES_NOEXCEPT(cbegin());
+STANDARD_REQUIRES_NOEXCEPT(cend());
+STANDARD_REQUIRES_NOEXCEPT(rbegin());
+STANDARD_REQUIRES_NOEXCEPT(rend());
+STANDARD_REQUIRES_NOEXCEPT(crbegin());
+STANDARD_REQUIRES_NOEXCEPT(crend());
+STANDARD_REQUIRES_NOEXCEPT(clear());
 
-// the two that legitimately can throw: at() checks the index, shrink_to_fit() allocates
-SAME_AS_STD_VECTOR(at(0));
-SAME_AS_STD_VECTOR(shrink_to_fit());
+#undef STANDARD_REQUIRES_NOEXCEPT
 
-#undef SAME_AS_STD_VECTOR
+// Past that the standard leaves it open and the implementations disagree: libstdc++ and the MSVC
+// STL declare pop_back noexcept, libc++ does not. None of them can throw in svector, so these are
+// our own promise and are checked on their own rather than against whichever std::vector we
+// happen to be building with.
+static_assert(noexcept(sv.operator[](0)));
+static_assert(noexcept(sv.front()));
+static_assert(noexcept(sv.back()));
+static_assert(noexcept(sv.pop_back()));
+
+// The two that really can throw. at() reports a bad index, and shrink_to_fit() allocates and lets
+// a failure through instead of quietly doing nothing the way libc++'s vector does.
+static_assert(!noexcept(sv.at(0)));
+static_assert(!noexcept(sv.shrink_to_fit()));
 
 TEST_CASE("noexcept_throwing_move_propagates") {
     // Before the fix this called std::terminate instead of unwinding.


### PR DESCRIPTION
Fixes #63, plus an audit of every other method.

## 1. The move operations promised something they cannot keep

`std::vector` can declare its move `noexcept` unconditionally because it only steals a pointer. An `svector` in direct mode has to relocate the inline elements, which runs `T`'s move constructor. Claiming `noexcept` anyway meant a throwing move called `std::terminate`, and — worse — `std::move_if_noexcept` asks exactly this trait, so growing a `std::vector<svector<T>>` moved instead of falling back to copy and turned `push_back`'s strong guarantee into an abort.

Both are now `noexcept(std::is_nothrow_move_constructible_v<T>)`. `boost::container::small_vector` is conditional here for the same reason:

```
boost small_vector<std::string,4>  nothrow_move = 1
boost small_vector<ThrowingMove,4> nothrow_move = 0
```

Nothing ordinary is affected — `std::string`, `std::vector`, `std::unique_ptr`, anything trivially copyable all keep the answer they had.

## 2. A leak, found by testing the above

Once a throwing-move type could actually be tested, asan immediately caught this:

```
Direct leak of 96 byte(s) in 1 object(s) allocated from:
    #1 in alloc                          svector.h:171
    #2 in emplace_back_grow<int const&>  svector.h:323
    #3 in emplace_back<int const&>       svector.h:830
```

Growing allocates new storage, builds the new element into it, then relocates the existing elements. If `T`'s move constructor throws partway through that relocation, the new storage was owned by nothing yet and the already-built element was never destroyed — both leaked. `take_over_storage()` now frees them on the way out.

This is pre-existing and only reachable with a throwing move, which is precisely why the unconditional `noexcept` kept it hidden.

## 3. Everything else was missing `noexcept` entirely

Probing `svector<std::string, 4>` against `std::vector<std::string>` before this PR: **every** entry except the two move operations answered `0` where `std::vector` answered `1` — `size()`, `capacity()`, `empty()`, `max_size()`, `data()`, all eight iterator accessors, `operator[]`, `front()`, `back()`, `clear()`, `pop_back()`, `swap()`, and the default constructor.

None of them can throw; they simply never said so. After this PR the two contracts are byte-identical:

```
$ diff <(probe svector) <(probe std::vector) && echo IDENTICAL
CONTRACT IDENTICAL to std::vector
```

`swap()` is the one that needed thought — it is a move construction plus two move assignments, so it takes the same condition as those.

Left alone deliberately: `at()` throws `out_of_range` by design, `shrink_to_fit()` allocates. Both match `std::vector` in still being able to throw.

## Tests

New `test/unit/noexcept_contract.cpp`. The contract assertions compare against `std::vector` rather than a hardcoded expectation, so the two cannot drift apart, and the macro stringifies the member so a failure says which one:

```
error: static assertion failed: clear()
```

Plus four runtime cases: a throwing move now unwinds instead of terminating (construction and assignment), an indirect move still never touches the elements, `std::vector` growth keeps the strong guarantee, and the leak above is caught under asan.

Verified green with gcc and clang under `-fsanitize=address,undefined`. Benchmarked the growth path A/B — the added `try`/`catch` costs nothing measurable, as expected for table-based EH.