### PR TITLE
Fix insert() of an empty range blanking the tail

### DIFF
--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -559,6 +559,13 @@ class svector {
      * Destroys then empty elements in [source_begin, source_end(
      */
     static void shift_right(T* source_begin, T* source_end, T* target_begin) {
+        if (source_begin == target_begin) {
+            // Shifting by zero. Not just a shortcut: std::move_backward below would be called with
+            // its destination equal to its source end, which it explicitly does not allow, and it
+            // would self-move-assign every element in the range. See issue #65.
+            return;
+        }
+
         // 1. uninitialized moves
         auto const num_moves = std::distance(source_begin, source_end);
         auto const target_end = target_begin + num_moves;

--- a/test/unit/insert.cpp
+++ b/test/unit/insert.cpp
@@ -167,3 +167,53 @@ TEST_CASE("insert_input_iterator") {
 }
 
 // iterator insert(const_iterator pos, std::initializer_list<T> ilist);
+// An empty insert has to leave the container exactly as it was. It used to shift by zero, which
+// self-move-assigned every element from pos onwards and blanked them. See issue #65.
+//
+// std::string is what makes this visible: Counter::Obj's move assignment copies its fields, so a
+// self-move preserves the value and the corruption cannot be observed. See issue #67.
+TEST_CASE("insert_nothing_keeps_the_elements") {
+    // long enough that the string allocates, so a self-move can't be hidden by SSO
+    auto const a = std::string("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    auto const b = std::string("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    auto const c = std::string("cccccccccccccccccccccccccccccccccccc");
+    auto const source = std::vector<std::string>{a, b, c};
+
+    for (size_t pos = 0; pos <= 3; ++pos) {
+        auto sv = ankerl::svector<std::string, 4>{a, b, c};
+        auto vec = std::vector<std::string>{a, b, c};
+
+        auto* it_sv = sv.insert(sv.cbegin() + pos, 0, a);
+        auto it_vec = vec.insert(vec.cbegin() + pos, 0, a);
+        REQUIRE(it_sv == sv.begin() + pos); // "or p if n == 0"
+        REQUIRE(it_vec == vec.begin() + pos);
+        assert_eq(vec, sv);
+
+        // forward iterators, empty range
+        sv.insert(sv.cbegin() + pos, source.begin(), source.begin());
+        vec.insert(vec.cbegin() + pos, source.begin(), source.begin());
+        assert_eq(vec, sv);
+
+        // empty initializer list
+        sv.insert(sv.cbegin() + pos, std::initializer_list<std::string>{});
+        vec.insert(vec.cbegin() + pos, std::initializer_list<std::string>{});
+        assert_eq(vec, sv);
+    }
+}
+
+// same thing once the vector is indirect, so both storage modes are covered
+TEST_CASE("insert_nothing_keeps_the_elements_indirect") {
+    auto sv = ankerl::svector<std::string, 4>();
+    auto vec = std::vector<std::string>();
+    for (int i = 0; i < 50; ++i) {
+        auto const s = std::string(40, static_cast<char>('a' + (i % 26)));
+        sv.push_back(s);
+        vec.push_back(s);
+    }
+    // more elements than fit inline, so this one is indirect
+    REQUIRE(sv.size() > ankerl::svector<std::string, 4>().capacity());
+
+    sv.insert(sv.cbegin() + 10, 0, std::string("x"));
+    vec.insert(vec.cbegin() + 10, 0, std::string("x"));
+    assert_eq(vec, sv);
+}


### PR DESCRIPTION
Fixes #65.

`v.insert(pos, 0, value)` blanked every element from `pos` onwards. No exception, no sanitizer report, just wrong data:

```
insert(begin(), 0, value)
  svector       [<EMPTY!> <EMPTY!> <EMPTY!> ]
  std::vector   [aaaa... bbbb... cccc... ]
```

## Cause

`make_uninitialized_space` calls `shift_right(p, data + s, p + count)`. With `count == 0` the target begin equals the source begin, so the second step becomes `std::move_backward(first, last, last)` — destination equal to source end, which that algorithm explicitly disallows. It walks backwards self-move-assigning every element in the range.

Affects `insert(pos, 0, value)`, `insert(pos, first, first)` (forward iterators) and `insert(pos, {})`. The input-iterator overload already had an empty-range early-out, which is why it escaped.

## Where the guard goes

In `shift_right`, not at the call site. Its documented precondition is `source_begin <= target_begin` — non-strict, so the equal case was always advertised as valid input and the implementation simply did not honour it. Guarding the one caller instead would leave the primitive a footgun for the next one.

The review raised that `count == 0` at the call site is easier for the compiler to fold than pointer equality inside the callee. Benchmarked both placements:

| | guard in `shift_right` | guard in caller |
|---|---:|---:|
| `insert(begin(), value)` int | 19.55 / 19.77 ns | 19.63 / 19.52 ns |
| `insert(mid, value)` int | 13.07 / 13.04 ns | 13.05 / 13.61 ns |
| `insert(begin(), string)` | 138.15 / 137.58 ns | 137.13 / 135.97 ns |

No difference, so correctness of the primitive wins.

## Tests

Two cases in `test/unit/insert.cpp`, covering all three affected overloads at every position including the `pos == size` boundary, and once more in indirect mode. Both fail without the guard.

They use `std::string` deliberately. This file already had empty-range insert coverage, but with `Counter::Obj`, whose move assignment is a plain field copy — a self-move preserves the value, so the corruption was unobservable. That blind spot is #67.

Verified with gcc and clang under `-fsanitize=address,undefined`.