### PR TITLE
Fix erase() of an empty range blanking the tail

### DIFF
--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -475,15 +475,23 @@ class svector {
         set_size<D>(count);
     }
 
-    // Makes sure that to is not past the end iterator
+    // Makes sure that to is not past the end iterator, and does nothing when that leaves an empty
+    // range to erase
     template <direction D>
     auto erase_checked_end(T const* cfrom, T const* to) -> T* {
         auto* const erase_begin = const_cast<T*>(cfrom); // NOLINT(cppcoreguidelines-pro-type-const-cast)
         auto* const container_end = data<D>() + size<D>();
         auto* const erase_end = (std::min)(const_cast<T*>(to), container_end); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+        auto const num_erased = std::distance(erase_begin, erase_end);
+
+        if (num_erased == 0) {
+            // Not just a shortcut: std::move below would be handed a destination equal to its
+            // source begin, which it does not allow, and it would self-move-assign every element
+            // from here to the end. See issue #66.
+            return erase_begin;
+        }
 
         std::move(erase_end, container_end, erase_begin);
-        auto const num_erased = std::distance(erase_begin, erase_end);
         std::destroy(container_end - num_erased, container_end);
         set_size<D>(size<D>() - num_erased);
         return erase_begin;

--- a/test/app/VecTester.h
+++ b/test/app/VecTester.h
@@ -8,7 +8,24 @@
 
 #include <cstddef>
 #include <stdexcept>
+#include <string>
 #include <vector>
+
+/**
+ * @brief count distinct strings, each long enough that it really allocates.
+ *
+ * Some bugs only show up on a type whose move assignment does something. std::string qualifies,
+ * but only while it is too long for the small string optimization, otherwise a self-move leaves
+ * the bytes in place and the damage is invisible. See issue #67.
+ */
+inline auto make_long_strings(size_t count) -> std::vector<std::string> {
+    auto v = std::vector<std::string>();
+    v.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        v.emplace_back(40, static_cast<char>('a' + (i % 26)));
+    }
+    return v;
+}
 
 template <typename VecA, typename VecB>
 void assert_eq(VecA const& a, VecB const& b) {

--- a/test/unit/erase.cpp
+++ b/test/unit/erase.cpp
@@ -1,8 +1,12 @@
 #include <ankerl/svector.h>
 
 #include <app/Counter.h>
+#include <app/VecTester.h>
 
 #include <doctest.h>
+
+#include <string>
+#include <vector>
 
 TEST_CASE("erase_single") {
     auto counts = Counter();
@@ -60,4 +64,22 @@ TEST_CASE("erase_range") {
     sv.erase(sv.begin(), sv.end() - 1);
     REQUIRE(sv.size() == 1);
     REQUIRE(sv.front().get() == 9);
+}
+
+// Erasing an empty range has to leave the container exactly as it was. It used to move the tail
+// onto itself, self-move-assigning every element from first onwards and blanking them. See #66.
+TEST_CASE("erase_nothing_keeps_the_elements") {
+    // 3 stays inline, 50 is indirect
+    for (auto const count : {size_t{3}, size_t{50}}) {
+        auto const source = make_long_strings(count);
+        for (auto const pos : {size_t{0}, count / 2, count}) {
+            auto sv = ankerl::svector<std::string, 4>(source.begin(), source.end());
+            auto vec = source;
+
+            auto* it = sv.erase(sv.cbegin() + pos, sv.cbegin() + pos);
+            vec.erase(vec.cbegin() + pos, vec.cbegin() + pos);
+            REQUIRE(it == sv.begin() + pos);
+            assert_eq(vec, sv);
+        }
+    }
 }

--- a/test/unit/insert.cpp
+++ b/test/unit/insert.cpp
@@ -203,13 +203,9 @@ TEST_CASE("insert_nothing_keeps_the_elements") {
 
 // same thing once the vector is indirect, so both storage modes are covered
 TEST_CASE("insert_nothing_keeps_the_elements_indirect") {
-    auto sv = ankerl::svector<std::string, 4>();
-    auto vec = std::vector<std::string>();
-    for (int i = 0; i < 50; ++i) {
-        auto const s = std::string(40, static_cast<char>('a' + (i % 26)));
-        sv.push_back(s);
-        vec.push_back(s);
-    }
+    auto const vec_source = make_long_strings(50);
+    auto sv = ankerl::svector<std::string, 4>(vec_source.begin(), vec_source.end());
+    auto vec = vec_source;
     // more elements than fit inline, so this one is indirect
     REQUIRE(sv.size() > ankerl::svector<std::string, 4>().capacity());
 


### PR DESCRIPTION
Fixes #66. Same class of bug as #65, different function.

`v.erase(it, it)` blanked every element from `it` onwards:

```
erase(it, it)
  svector       [<EMPTY!> <EMPTY!> <EMPTY!> ]
  std::vector   [aaaa... bbbb... cccc... ]
```

`erase_checked_end` ran `std::move(erase_end, container_end, erase_begin)` unconditionally. With `first == last` the destination equals the source begin, which `std::move` does not allow, and every element self-move-assigns.

## This was the last one

Grepped the whole header for the assigning algorithms. There are exactly two raw call sites:

| line | call | status |
|---|---|---|
| 492 | `std::move(...)` in `erase_checked_end` | fixed here |
| 581 | `std::move_backward(...)` in `shift_right` | fixed in #65 |

Every other data movement goes through `std::uninitialized_move` / `std::uninitialized_copy` / `std::uninitialized_fill_n`, which construct into raw memory and so cannot self-assign. The remaining `std::move` hits are the single-object cast, not the algorithm. So this bug class is now fully covered.

## Depth

The guard belongs in `erase_checked_end`, not the public `erase()`: `to` is clamped against `container_end` first, so a range can be non-empty on entry and still clamp to empty. Checking `first == last` in the caller would miss that case, and re-deriving the clamp there would duplicate the logic.

It reuses `num_erased` (hoisted above the guard) instead of spelling "nothing to erase" a second way as a pointer comparison.

## Tests

One case in `test/unit/erase.cpp`, covering begin/middle/end positions in both storage modes. Fails without the guard.

`make_long_strings()` moved into `test/app/VecTester.h` — #65's test grew the same "strings long enough to defeat SSO" scaffolding in `insert.cpp`, and this would have been the second copy. Both now call the helper.

Verified with gcc and clang under `-fsanitize=address,undefined`.