### PR TITLE
Make the test element type notice self move assignment

### DIFF
--- a/test/app/Counter.cpp
+++ b/test/app/Counter.cpp
@@ -140,6 +140,17 @@ auto Counter::Obj::operator=(const Counter::Obj& o) -> Counter::Obj& {
 }
 
 auto Counter::Obj::operator=(Counter::Obj&& o) noexcept -> Counter::Obj& {
+    // A container moving an element onto itself means it handed an overlapping range to
+    // std::move or std::move_backward, which neither allows. That was #65 and #66, and the plain
+    // field copy below hid both: a self move keeps the value, so the differential tests saw
+    // nothing. Deliberately not under COUNTER_ENABLE_UNORDERED_SET, it costs one comparison.
+    //
+    // Only sound because Obj exists to be put into containers. x = std::move(x) written by hand
+    // is allowed to leave x in any valid state, so a general purpose type could not check this.
+    if (this == &o) {
+        test::print("ERROR at {}({}): {} self move assignment\n", __FILE__, __LINE__, __func__);
+        std::abort();
+    }
 #if COUNTER_ENABLE_UNORDERED_SET
     if (1 != singletonConstructedObjects().count(this) || 1 != singletonConstructedObjects().count(&o)) {
         test::print("ERROR at {}({}): {}\n", __FILE__, __LINE__, __func__);


### PR DESCRIPTION
Fixes #67.

`Counter::Obj::operator=(Obj&&)` is a plain field copy, so moving an object onto itself preserves its value. That is why #65 and #66 survived: both were pure data corruption, `test/fuzz/api.cpp` generates exactly the inputs that trigger them, and it compares against `std::vector` after every operation — and still saw nothing.

## Proof it works

With both fixes reverted:

```
--- Counter::Obj insert test (previously passed with the bug live) ---
ERROR at test/app/Counter.cpp(151): operator= self move assignment
test/unit/insert.cpp:112: FATAL ERROR: test case CRASHED: SIGABRT

--- fuzz corpus ---
1/1651  ERROR at test/app/Counter.cpp(151): operator= self move assignment
```

`insert_input_iterator` is a pre-existing test that **passed** while the bug was live. The fuzz corpus fails on its first of 1651 entries.

With the fixes in place the whole suite is clean, so no legitimate operation in the library self-move-assigns.

## Why this and not a std::string fuzz lane

The issue suggested either. Detecting it in the element type turns out to be strictly stronger:

- A `std::string` lane depends on **implementation-defined** behaviour. `[container.reqmts]` only promises "valid but unspecified" after a self-move; libstdc++ happening to leave the string empty is not a guarantee. A future stdlib or a different SSO threshold could silently restore the blind spot.
- It only catches the bug if the damaged element survives to a comparison point. Several `repeat_oneof` branches tear down and rebuild the containers with `assertEq` commented out.
- The element-type check fires **at the point of the violation**, regardless of whether the value happened to change or anyone looked afterwards.

It is also a 4-line change rather than duplicating the whole harness, every branch of which is wired to `Counter::Obj` bookkeeping (`c.set(counts)`, `counts.check_all_done()`) with no `std::string` analogue.

## Two deliberate deviations from the file's convention

The other invariant checks here sit inside `#if COUNTER_ENABLE_UNORDERED_SET`. This one does not: that macro guards two hash-set lookups per call, while this is a single pointer comparison worth having unconditionally. `Counter::Obj` is not used by any benchmark, so nothing measured is affected.

The message carries `"self move assignment"` rather than the bare `__func__` the other sites use, because `__func__` is `operator=` for both the copy and move overloads.

## Known remaining gap

This catches self-move only. A double-move (same source moved into two destinations) would still pass, because `Obj`'s move leaves the source untouched, so the duplicate looks valid. Marking the source moved-from and rejecting a second move would cover it — worth a follow-up, not done here.