### PR TITLE
Fix insert() leaving an undestroyable container when a constructor throws

### DIFF
--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -618,11 +618,70 @@ class svector {
     // Invalidates every reference into the container: the elements from pos onwards are either
     // shifted right or moved into a fresh allocation. A T const& argument that might be one of
     // our own elements has to be copied out of the way first, see is_reference_into_self().
+    //
+    // size() already counts the gap when this returns, so between here and the caller filling it
+    // the container is claiming raw memory. Whoever constructs into the gap has to call
+    // close_gap() if that throws, see issue #68.
     [[nodiscard]] auto make_uninitialized_space(T const* pos, size_t count) -> T* {
         if (is_direct()) {
             return make_uninitialized_space<direction::direct>(pos, count);
         }
         return make_uninitialized_space<direction::indirect>(pos, count);
+    }
+
+    /**
+     * @brief Makes room for count elements at pos and has fill construct them into it.
+     *
+     * fill(p) has to construct all count elements at p, or none: the standard uninitialized_*
+     * algorithms clean up after themselves, and a single placement new either works or builds
+     * nothing. If it throws, the gap is closed again before the exception continues.
+     */
+    template <typename Fill>
+    auto fill_uninitialized_space(T const* pos, size_t count, Fill fill) -> T* {
+        auto* p = make_uninitialized_space(pos, count);
+        try {
+            fill(p);
+        } catch (...) {
+            close_gap(p, count);
+            throw;
+        }
+        return p;
+    }
+
+    /**
+     * @brief Undoes a make_uninitialized_space() whose gap could not be filled.
+     *
+     * Precondition: nothing is constructed in [gap_begin, gap_begin + count). The standard
+     * algorithms used to fill it destroy whatever they managed to build before rethrowing, and a
+     * single placement new either succeeds or constructs nothing.
+     *
+     * Runs while an exception is in flight, so it must not throw itself. When relocating a T
+     * cannot throw we shift the tail back down and end up with exactly the elements we started
+     * with. Otherwise the only safe thing left is to drop the tail, which still leaves a container
+     * that is valid and destroys cleanly, just shorter. std::move_if_noexcept, which is how one
+     * would normally keep the elements of a throwing-move type, is not available here: falling
+     * back to a copy could throw a second exception during unwinding and call std::terminate.
+     */
+    void close_gap(T* gap_begin, size_t count) noexcept {
+        auto* const first = data();
+        auto* const last = first + size();
+        auto* const tail = gap_begin + count;
+
+        if constexpr (std::is_nothrow_move_constructible_v<T> && std::is_nothrow_move_assignable_v<T>) {
+            // Mirror image of shift_right: the destination starts with the raw gap, which has to
+            // be constructed into, and only what lands past it can be assigned.
+            auto const tail_size = static_cast<size_t>(last - tail);
+            auto const num_uninitialized_move = (std::min)(count, tail_size);
+            std::uninitialized_move_n(tail, num_uninitialized_move, gap_begin);
+            std::move(tail + num_uninitialized_move, last, gap_begin + num_uninitialized_move);
+
+            // whatever the shift did not overwrite is moved-from but still alive
+            std::destroy((std::max)(gap_begin + tail_size, tail), last);
+            set_size(size() - count);
+        } else {
+            std::destroy(tail, last);
+            set_size(static_cast<size_t>(gap_begin - first));
+        }
     }
 
     void destroy() {
@@ -1020,8 +1079,9 @@ public:
         // dangling. Build the element first. Inserting in the middle already moves every
         // element after pos, so one extra move does not change the cost.
         auto tmp = T(std::forward<Args>(args)...);
-        auto* p = make_uninitialized_space(pos, 1);
-        return new (static_cast<void*>(p)) T(std::move(tmp));
+        return fill_uninitialized_space(pos, 1, [&](T* p) {
+            new (static_cast<void*>(p)) T(std::move(tmp));
+        });
     }
 
     auto insert(const_iterator pos, T const& value) -> iterator {
@@ -1033,8 +1093,9 @@ public:
         }
         // not aliasing, so we can make space first and construct straight into it. Going
         // through emplace() would build a temporary and then move it, for no reason.
-        auto* p = make_uninitialized_space(pos, 1);
-        return new (static_cast<void*>(p)) T(value);
+        return fill_uninitialized_space(pos, 1, [&](T* p) {
+            new (static_cast<void*>(p)) T(value);
+        });
     }
 
     auto insert(const_iterator pos, T&& value) -> iterator {
@@ -1042,8 +1103,9 @@ public:
             auto tmp = std::move(value);
             return insert(pos, std::move(tmp));
         }
-        auto* p = make_uninitialized_space(pos, 1);
-        return new (static_cast<void*>(p)) T(std::move(value));
+        return fill_uninitialized_space(pos, 1, [&](T* p) {
+            new (static_cast<void*>(p)) T(std::move(value));
+        });
     }
 
     auto insert(const_iterator pos, size_t count, T const& value) -> iterator {
@@ -1053,9 +1115,9 @@ public:
             auto const tmp = value;
             return insert(pos, count, tmp);
         }
-        auto* p = make_uninitialized_space(pos, count);
-        std::uninitialized_fill_n(p, count, value);
-        return p;
+        return fill_uninitialized_space(pos, count, [&](T* p) {
+            std::uninitialized_fill_n(p, count, value);
+        });
     }
 
     template <typename It>
@@ -1080,9 +1142,10 @@ public:
 
     template <typename It>
     auto insert(const_iterator pos, It first, It last, std::forward_iterator_tag /*unused*/) -> iterator {
-        auto* p = make_uninitialized_space(pos, std::distance(first, last));
-        std::uninitialized_copy(first, last, p);
-        return p;
+        auto const count = static_cast<size_t>(std::distance(first, last));
+        return fill_uninitialized_space(pos, count, [&](T* p) {
+            std::uninitialized_copy(first, last, p);
+        });
     }
 
     template <typename InputIt, typename = detail::enable_if_t<detail::is_input_iterator<InputIt>>>

--- a/test/meson.build
+++ b/test/meson.build
@@ -27,6 +27,7 @@ test_sources = [
     'unit/fuzz_corpus.cpp',
     'unit/includes_only.cpp',
     'unit/insert.cpp',
+    'unit/insert_exception_safety.cpp',
     'unit/member_types.cpp',
     'unit/move_relocation.cpp',
     'unit/n_eq_0.cpp',

--- a/test/unit/insert_exception_safety.cpp
+++ b/test/unit/insert_exception_safety.cpp
@@ -1,0 +1,215 @@
+// Tests for https://github.com/martinus/svector/issues/68
+//
+// make_uninitialized_space() shifts the elements from pos out of the way and immediately counts
+// the resulting gap in size(). Until the caller has constructed into that gap the container is
+// claiming raw memory, so a throwing element constructor used to leave it in a state that could
+// not even be destroyed: the destructor ran over slots that were never built, or over slots the
+// filling algorithm had already cleaned up, which is a double destroy.
+//
+// Run under asan, the failures here are use-after-free and leaks rather than wrong values.
+
+#include <ankerl/svector.h>
+#include <app/VecTester.h>
+
+#include <doctest.h>
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Copying throws once the budget runs out, moving never does. This is the ordinary case: a type
+// whose copy can fail because it allocates, like std::string.
+struct ThrowOnCopy {
+    std::string value;
+
+    static int budget; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+    explicit ThrowOnCopy(std::string v)
+        : value(std::move(v)) {}
+
+    ThrowOnCopy(ThrowOnCopy const& other)
+        : value(other.value) {
+        if (--budget < 0) {
+            throw std::runtime_error("copy");
+        }
+    }
+
+    ThrowOnCopy(ThrowOnCopy&&) noexcept = default;
+    auto operator=(ThrowOnCopy const&) -> ThrowOnCopy& = default;
+    auto operator=(ThrowOnCopy&&) noexcept -> ThrowOnCopy& = default;
+    ~ThrowOnCopy() = default;
+
+    auto operator==(ThrowOnCopy const& other) const -> bool {
+        return value == other.value;
+    }
+};
+
+int ThrowOnCopy::budget = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+static_assert(std::is_nothrow_move_constructible_v<ThrowOnCopy>);
+static_assert(std::is_nothrow_move_assignable_v<ThrowOnCopy>);
+
+// Same, but relocating it can throw too, so the container cannot shift the tail back and has to
+// fall back to dropping it. All that is promised then is that nothing leaks.
+struct ThrowOnCopyAndMove {
+    std::string value;
+
+    static int budget; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+    explicit ThrowOnCopyAndMove(std::string v)
+        : value(std::move(v)) {}
+
+    ThrowOnCopyAndMove(ThrowOnCopyAndMove const& other)
+        : value(other.value) {
+        if (--budget < 0) {
+            throw std::runtime_error("copy");
+        }
+    }
+
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ThrowOnCopyAndMove(ThrowOnCopyAndMove&& other)
+        : value(std::move(other.value)) {}
+
+    auto operator=(ThrowOnCopyAndMove const&) -> ThrowOnCopyAndMove& = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    auto operator=(ThrowOnCopyAndMove&& other) -> ThrowOnCopyAndMove& {
+        value = std::move(other.value);
+        return *this;
+    }
+    ~ThrowOnCopyAndMove() = default;
+};
+
+int ThrowOnCopyAndMove::budget = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+static_assert(!std::is_nothrow_move_constructible_v<ThrowOnCopyAndMove>);
+
+auto make(size_t count) -> ankerl::svector<ThrowOnCopy, 4> {
+    auto v = ankerl::svector<ThrowOnCopy, 4>();
+    for (auto& s : make_long_strings(count)) {
+        v.emplace_back(std::move(s));
+    }
+    return v;
+}
+
+auto contents(ankerl::svector<ThrowOnCopy, 4> const& v) -> std::vector<std::string> {
+    auto out = std::vector<std::string>();
+    for (auto const& e : v) {
+        out.push_back(e.value);
+    }
+    return out;
+}
+
+} // namespace
+
+TEST_CASE("insert_count_throwing_copy_keeps_container_intact") {
+    auto const filler = ThrowOnCopy(std::string(40, 'z'));
+
+    // sizes on both sides of the inline capacity, counts that do and do not force a reallocation
+    for (size_t size = 0; size <= 9; ++size) {
+        for (size_t pos = 0; pos <= size; ++pos) {
+            for (size_t count = 1; count <= 5; ++count) {
+                // uninitialized_fill_n destroys whatever it built before rethrowing, so close_gap
+                // sees the same empty gap whichever copy failed. First and last is enough.
+                for (auto const throw_at : {size_t{0}, count - 1}) {
+                    auto v = make(size);
+                    auto const before = contents(v);
+
+                    ThrowOnCopy::budget = static_cast<int>(throw_at);
+                    REQUIRE_THROWS_AS(v.insert(v.cbegin() + pos, count, filler), std::runtime_error);
+                    ThrowOnCopy::budget = 1000000;
+
+                    // moving cannot throw for this type, so the insert rolls all the way back
+                    REQUIRE(contents(v) == before);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("insert_range_throwing_copy_keeps_container_intact") {
+    auto const source = std::vector<ThrowOnCopy>{
+        ThrowOnCopy(std::string(40, 'x')),
+        ThrowOnCopy(std::string(40, 'y')),
+        ThrowOnCopy(std::string(40, 'z')),
+    };
+
+    for (size_t size = 0; size <= 9; ++size) {
+        for (size_t pos = 0; pos <= size; ++pos) {
+            for (auto const throw_at : {size_t{0}, source.size() - 1}) {
+                auto v = make(size);
+                auto const before = contents(v);
+
+                ThrowOnCopy::budget = static_cast<int>(throw_at);
+                REQUIRE_THROWS_AS(v.insert(v.cbegin() + pos, source.begin(), source.end()), std::runtime_error);
+                ThrowOnCopy::budget = 1000000;
+
+                REQUIRE(contents(v) == before);
+            }
+        }
+    }
+}
+
+TEST_CASE("insert_single_throwing_copy_keeps_container_intact") {
+    auto const filler = ThrowOnCopy(std::string(40, 'z'));
+
+    for (size_t size = 0; size <= 9; ++size) {
+        for (size_t pos = 0; pos <= size; ++pos) {
+            auto v = make(size);
+            auto const before = contents(v);
+
+            ThrowOnCopy::budget = 0;
+            REQUIRE_THROWS_AS(v.insert(v.cbegin() + pos, filler), std::runtime_error);
+            ThrowOnCopy::budget = 1000000;
+
+            REQUIRE(contents(v) == before);
+        }
+    }
+}
+
+TEST_CASE("emplace_throwing_copy_keeps_container_intact") {
+    auto const filler = ThrowOnCopy(std::string(40, 'z'));
+
+    for (size_t size = 1; size <= 9; ++size) {
+        for (size_t pos = 0; pos < size; ++pos) { // pos == size goes through emplace_back
+            auto v = make(size);
+            auto const before = contents(v);
+
+            ThrowOnCopy::budget = 0;
+            REQUIRE_THROWS_AS(v.emplace(v.cbegin() + pos, filler), std::runtime_error);
+            ThrowOnCopy::budget = 1000000;
+
+            REQUIRE(contents(v) == before);
+        }
+    }
+}
+
+TEST_CASE("insert_throwing_move_leaves_a_destructible_container") {
+    // Relocating can throw here, so the tail cannot be shifted back and gets dropped instead. The
+    // container is shorter than it was, which the standard allows, but it has to be consistent:
+    // asan and the leak checker are what actually assert that.
+    for (size_t size = 0; size <= 9; ++size) {
+        for (size_t pos = 0; pos <= size; ++pos) {
+            for (size_t count = 1; count <= 3; ++count) {
+                auto v = ankerl::svector<ThrowOnCopyAndMove, 4>();
+                ThrowOnCopyAndMove::budget = 1000000;
+                for (auto& s : make_long_strings(size)) {
+                    v.emplace_back(std::move(s));
+                }
+
+                auto const filler = ThrowOnCopyAndMove(std::string(40, 'z'));
+                ThrowOnCopyAndMove::budget = 0;
+                REQUIRE_THROWS_AS(v.insert(v.cbegin() + pos, count, filler), std::runtime_error);
+                ThrowOnCopyAndMove::budget = 1000000;
+
+                REQUIRE(v.size() <= size);
+                // everything still there has to be readable and destroy cleanly
+                for (auto const& e : v) {
+                    REQUIRE(e.value.size() == 40);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #68.

`make_uninitialized_space()` shifts the elements at `pos` out of the way and immediately counts the resulting gap in `size()`. Until the caller constructs into that gap the container claims raw memory, so a throwing element constructor left it in a state that could not even be destroyed:

```
size=2 capacity=8
inserting 3 copies, the 2nd throws...
caught: copy
after: size=5
ERROR: AddressSanitizer: heap-use-after-free
  #6 ThrowOnCopy::~ThrowOnCopy()
  #7 std::_Destroy<ThrowOnCopy>(ThrowOnCopy*)
```

`size()` says 5 while slots 0 and 1 hold objects `std::uninitialized_fill_n` had already destroyed on its way out.

## Fix

All five callers (`emplace`, both single `insert`s, the count `insert`, the forward-iterator range `insert`) now go through `fill_uninitialized_space()`, which closes the gap again if the fill throws.

`close_gap()` has two modes:

- **relocating T cannot throw** — shift the tail back down; the container ends up exactly as it started.
- **otherwise** — drop the tail. Shorter, but valid and destroys cleanly.

`std::move_if_noexcept`, the usual way to preserve elements of a throwing-move type, is deliberately not used: `close_gap` runs mid-unwind, and a throwing copy there would be a second exception in flight and `std::terminate`.

That split matches the standard. [sequence.reqmts] only requires the strong guarantee for a middle insert when moving cannot throw, and the basic guarantee otherwise.

## Tests

`test/unit/insert_exception_safety.cpp` sweeps sizes 0-9 × every position × counts 1-5 × first/last throw point, across `insert(pos, count, v)`, `insert(pos, first, last)`, `insert(pos, v)` and `emplace`, in both storage modes and across the reallocating boundary. For the nothrow-move type it asserts the contents are byte-identical to before; for the throwing-move type asan and the leak checker do the asserting.

Reverting the guard reproduces the heap-use-after-free immediately.

## Measured cost

Reviewed the codegen rather than assuming. For `svector<int, 8>` the `try`/`catch` is fully elided — identical `.text` size (5851 bytes), no landing pads, no `.gcc_except_table` entries. For `svector<std::string, 8>` the TU grows 3.9%, almost all of it one out-of-line `close_gap` per `T` — it is not templated on the lambda, so the five call sites share it. `fill_uninitialized_space` inlines away entirely at `-O3`.

## Not fixed here

`make_uninitialized_space_new()` has the same shape of bug on the growth path: if a move throws partway through relocating into the new storage, the elements already moved are leaked. Confirmed with asan and filed as #74, along with the deeper redesign that would remove this whole family of problems.