### PR TITLE
Fix insert(pos, count, value) overflowing instead of throwing

### DIFF
--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -604,7 +604,16 @@ class svector {
     [[nodiscard]] auto make_uninitialized_space(T const* pos, size_t count) -> T* {
         auto* const p = const_cast<T*>(pos); // NOLINT(cppcoreguidelines-pro-type-const-cast)
         auto s = size<D>();
-        if (s + count > capacity<D>()) {
+
+        // Both written as subtractions so neither can wrap: s <= max_size() and s <= capacity()
+        // always hold. It used to say s + count > capacity(), which overflowed for a huge count,
+        // and the wrapped sum then looked small enough to fit, so the in place shift below ran
+        // straight past the end of the buffer. See issue #69.
+        if (count > max_size() - s) {
+            throw std::bad_alloc();
+        }
+
+        if (count > capacity<D>() - s) {
             return make_uninitialized_space_new<D>(s, p, count);
         }
 

--- a/test/unit/insert.cpp
+++ b/test/unit/insert.cpp
@@ -7,6 +7,8 @@
 
 #include <forward_list>
 #include <iostream>
+#include <limits>
+#include <new>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -212,4 +214,33 @@ TEST_CASE("insert_nothing_keeps_the_elements_indirect") {
     sv.insert(sv.cbegin() + 10, 0, std::string("x"));
     vec.insert(vec.cbegin() + 10, 0, std::string("x"));
     assert_eq(vec, sv);
+}
+
+// make_uninitialized_space() decided whether the elements still fit with "s + count >
+// capacity()". A huge count wrapped that sum around to something small, so the check said yes and
+// the in place shift wrote past the end of the buffer. See issue #69.
+TEST_CASE("insert_count_too_large_throws") {
+    auto const huge = (std::numeric_limits<size_t>::max)();
+
+    // max_size() is the first count that cannot work, huge is the one that used to wrap
+    for (auto const count : {huge, ankerl::svector<int, 4>::max_size()}) {
+        auto v = ankerl::svector<int, 4>{1, 2, 3};
+        REQUIRE_THROWS_AS(v.insert(v.begin(), count, 5), std::bad_alloc);
+
+        // the failed insert left it alone
+        REQUIRE(v.size() == 3);
+        REQUIRE(v[0] == 1);
+        REQUIRE(v[2] == 3);
+    }
+}
+
+TEST_CASE("insert_count_too_large_throws_indirect") {
+    auto v = ankerl::svector<int, 4>();
+    for (int i = 0; i < 50; ++i) {
+        v.push_back(i);
+    }
+
+    REQUIRE_THROWS_AS(v.insert(v.begin() + 10, (std::numeric_limits<size_t>::max)(), 5), std::bad_alloc);
+    REQUIRE(v.size() == 50);
+    REQUIRE(v[10] == 10);
 }


### PR DESCRIPTION
Fixes #69.

```cpp
auto sv = ankerl::svector<int, 4>{1, 2, 3};
sv.insert(sv.begin(), SIZE_MAX - 1, 5);
```

```
std::vector: threw length_error
svector: size=3 capacity=5, inserting SIZE_MAX-1...
ERROR: AddressSanitizer: stack-buffer-overflow
  #4 svector<int, 4ul>::shift_right(int*, int*, int*)
  #7 svector<int, 4ul>::insert(int const*, unsigned long, int const&)
```

`s + count` wrapped, the wrapped sum looked small enough to fit, so the in-place shift ran past the end of the buffer.

## Fix

Both comparisons are now subtractions:

```cpp
if (count > max_size() - s) { throw std::bad_alloc(); }
if (count > capacity<D>() - s) { return make_uninitialized_space_new<D>(s, p, count); }
```

Neither can wrap, since `s` is never larger than `capacity()` or `max_size()`. The review pointed out that leaving the second one as `s + count > capacity()` and relying on the guard above would be a cross-line invariant a later edit could quietly break — each check is now correct on its own.

The existing overflow checks could not have caught this: `calculate_new_capacity()` only ever receives an already-summed size, and `storage<T>::alloc()` guards `capacity * sizeof(T)`. Both sit behind the wrapped comparison that decided not to reallocate at all.

## Audit of the other arithmetic

Checked every other size computation in the header. `reserve`, `resize`, `resize(count, value)`, `svector(count)`, `svector(count, value)`, `assign(count, value)` and `resize_and_overwrite` all pass a single bounded value into `calculate_new_capacity`, which already checks it against `max_size()` — no sum of two unbounded values, so nothing to wrap. `emplace_back_grow`'s `s + 1` is bounded by the size invariant. Every `s + count` in `make_uninitialized_space_new` is now downstream of the new guard. This was the only one.

## Exception type

`std::bad_alloc`, matching `calculate_new_capacity()` and `reserve()`. `std::vector` throws `std::length_error` for this specific case, which is arguably the better contract for a drop-in replacement, but `test/unit/bad_alloc.cpp` already pins `reserve(max_size())` to `bad_alloc` — introducing `length_error` for this one check would be a worse inconsistency than the existing divergence. Changing it library-wide is a separate decision.

## Cost

Reviewed the codegen: `max_size()` folds to an immediate, and the check is `movabs`/`sub`/`cmp+jb`. Benchmarked single-element insert, emplace, and count inserts — all within noise.

Tests live in `test/unit/insert.cpp` next to the other insert coverage; reverting the guard reproduces the stack-buffer-overflow.