### PR TITLE
Fix resize() leaking when an element constructor throws

### DIFF
--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -467,9 +467,18 @@ class svector {
                 std::destroy(d + count, d + current_size);
             }
         } else {
-            auto* d = data<D>();
-            for (auto ptr = d + current_size, end = d + count; ptr != end; ++ptr) {
-                new (static_cast<void*>(ptr)) T(std::forward<Args>(args)...);
+            // The hand written loop this replaces left everything it had already built behind when
+            // a constructor threw: the size still said current_size, so nothing ever destroyed
+            // them. These two clean up after themselves, which is the same reason insert() builds
+            // through them rather than looping. See issue #70.
+            //
+            // Value construction, not default construction: resize(n) on an svector<int> has to
+            // zero the new elements the way T() does.
+            auto* const first_new = data<D>() + current_size;
+            if constexpr (sizeof...(Args) == 0) {
+                std::uninitialized_value_construct_n(first_new, count - current_size);
+            } else {
+                std::uninitialized_fill_n(first_new, count - current_size, args...);
             }
         }
         set_size<D>(count);

--- a/test/unit/resize.cpp
+++ b/test/unit/resize.cpp
@@ -2,7 +2,10 @@
 #include <app/Counter.h>
 
 #include <doctest.h>
+
+#include <cstddef>
 #include <stdexcept>
+#include <string>
 
 TEST_CASE("resize") {
     Counter counts;
@@ -32,4 +35,89 @@ TEST_CASE("resize") {
 
     a.resize(0);
     REQUIRE(a.empty());
+}
+
+namespace {
+
+// Constructing throws once the budget runs out.
+struct ThrowOnConstruct {
+    std::string value;
+
+    static int budget; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+    ThrowOnConstruct()
+        : value(40, 'x') {
+        if (--budget < 0) {
+            throw std::runtime_error("ctor");
+        }
+    }
+
+    ThrowOnConstruct(ThrowOnConstruct const& other)
+        : value(other.value) {
+        if (--budget < 0) {
+            throw std::runtime_error("copy");
+        }
+    }
+
+    ThrowOnConstruct(ThrowOnConstruct&&) noexcept = default;
+    auto operator=(ThrowOnConstruct const&) -> ThrowOnConstruct& = default;
+    auto operator=(ThrowOnConstruct&&) noexcept -> ThrowOnConstruct& = default;
+    ~ThrowOnConstruct() = default;
+};
+
+int ThrowOnConstruct::budget = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+using SvThrowing = ankerl::svector<ThrowOnConstruct, 4>;
+
+} // namespace
+
+// resize_after_reserve() only recorded the new size once the whole construction loop had finished,
+// so a throwing constructor left everything it had already built unreachable and unreleased. Run
+// under asan, the leak checker is what asserts here. See issue #70.
+TEST_CASE("resize_throwing_ctor_does_not_leak") {
+    for (size_t start = 0; start <= 6; ++start) {
+        for (size_t target = start + 1; target <= 12; ++target) {
+            // the cleanup range does not depend on how many were built, first and last is enough
+            for (auto const built : {size_t{0}, target - start - 1}) {
+                auto v = SvThrowing();
+                ThrowOnConstruct::budget = 1000000;
+                v.resize(start);
+
+                ThrowOnConstruct::budget = static_cast<int>(built);
+                REQUIRE_THROWS_AS(v.resize(target), std::runtime_error);
+                ThrowOnConstruct::budget = 1000000;
+
+                // the failed resize did not commit, and nothing it built is left behind
+                REQUIRE(v.size() == start);
+            }
+        }
+    }
+}
+
+TEST_CASE("resize_with_value_throwing_copy_does_not_leak") {
+    ThrowOnConstruct::budget = 1000000;
+    auto const filler = ThrowOnConstruct();
+
+    for (size_t start = 0; start <= 6; ++start) {
+        for (size_t target = start + 1; target <= 12; ++target) {
+            auto v = SvThrowing();
+            ThrowOnConstruct::budget = 1000000;
+            v.resize(start);
+
+            ThrowOnConstruct::budget = static_cast<int>((target - start) / 2);
+            REQUIRE_THROWS_AS(v.resize(target, filler), std::runtime_error);
+            ThrowOnConstruct::budget = 1000000;
+
+            REQUIRE(v.size() == start);
+        }
+    }
+}
+
+TEST_CASE("svector_count_ctor_throwing_ctor_does_not_leak") {
+    for (size_t count = 1; count <= 12; ++count) {
+        ThrowOnConstruct::budget = static_cast<int>(count / 2);
+        // the extra cast keeps SvThrowing(count) from parsing as a declaration of count
+        REQUIRE_THROWS_AS(static_cast<void>(SvThrowing(count)), std::runtime_error);
+        ThrowOnConstruct::budget = 1000000;
+    }
 }


### PR DESCRIPTION
Fixes #70.

`resize_after_reserve()` constructed the new elements in a loop and only recorded the new size once the loop had finished. If element *k* threw, elements `current_size..k` were alive but the size never moved, so nothing ever destroyed them.

```
caught: ctor
done
Direct leak of 175 byte(s) in 5 object(s)
```

Exactly the 5 elements that had been constructed.

## Fix

My first attempt wrapped the loop in a `try`/`catch`. The review pushed back from four directions and it was right: the loop should not exist. `std::uninitialized_value_construct_n` and `std::uninitialized_fill_n` both destroy what they built before rethrowing, which is precisely the missing behaviour — and it is already why `insert()` constructs through them instead of looping. `fill_uninitialized_space`'s own doc comment says so.

```cpp
if constexpr (sizeof...(Args) == 0) {
    std::uninitialized_value_construct_n(first_new, count - current_size);
} else {
    std::uninitialized_fill_n(first_new, count - current_size, args...);
}
```

So the fix deletes code rather than adding it, and `resize_after_reserve` stops being the one place in the file that hand-rolls what the rest gets from the standard algorithms.

**One trap worth naming:** two of the four reviewers suggested `std::uninitialized_default_construct_n`. That would have been a silent regression — it default-initializes, so `resize(n)` on an `svector<int>` would leave the new elements holding garbage instead of zeroing them the way `T()` does. `value_construct` is the one that matches. Verified directly:

```
svector after regrow: 0 0 0 ... (mismatches vs std::vector: 0)
```

## Guarantee

Size and element values are unchanged on failure. Capacity may already have grown, because `reserve()` runs before the construction — `std::vector::resize` promises the strong guarantee including capacity, so this is the basic guarantee plus "size and values unchanged", not literally strong. That ordering predates this change.

## Tests

Three cases in `test/unit/resize.cpp` sweeping start sizes 0-6 × target sizes up to 12 × first/last throw point, across `resize(count)`, `resize(count, value)` and `svector(count)`. Reverting to the loop leaks 450 objects under LSan.

## Cost

Compared `-O3` codegen before and after: `.text` identical at 9749 bytes, no `.gcc_except_table` in either, and the `int` fill still vectorizes to the same `movups` sequence.

## Audit

Checked every other placement-new in the header. `emplace_back_grow` has its own guard, `emplace_back` constructs before committing the size, and the three single-element `insert`/`emplace` sites go through `fill_uninitialized_space`. This was the last multi-element construction loop without cleanup.