### PR TITLE
Insert without ever opening a gap of raw memory

### DIFF
--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -185,6 +185,42 @@ struct storage : public header {
     }
 };
 
+/**
+ * @brief Destroys [first, last) on the way out, unless it has been released.
+ *
+ * A half built container can normally describe what it has by its size, and then its own destructor
+ * is all the cleanup that is needed. This is for the one place where the constructed part is not a
+ * prefix, so no size can express it.
+ */
+template <typename T>
+class destroy_guard {
+    T* m_first;
+    T* m_last;
+
+public:
+    destroy_guard(T* first, T* last)
+        : m_first(first)
+        , m_last(last) {}
+
+    destroy_guard(destroy_guard const&) = delete;
+    destroy_guard(destroy_guard&&) = delete;
+    auto operator=(destroy_guard const&) -> destroy_guard& = delete;
+    auto operator=(destroy_guard&&) -> destroy_guard& = delete;
+
+    ~destroy_guard() {
+        std::destroy(m_first, m_last);
+    }
+
+    // The guarded range only ever grows to the front, and stays contiguous while it does.
+    void extend_front(T* first) {
+        m_first = first;
+    }
+
+    void release() {
+        m_last = m_first;
+    }
+};
+
 } // namespace detail
 
 template <typename T, size_t MinInlineCapacity>
@@ -566,53 +602,81 @@ class svector {
     }
 
     /**
-     * @brief Shifts data [source_begin, source_end( to the right, starting on target_begin.
+     * @brief How insert_n() puts new elements somewhere: source is a range of count of them.
      *
-     * Preconditions:
-     * * contiguous memory
-     * * source_begin <= target_begin
-     * * source_end onwards is uninitialized memory
-     *
-     * Destroys then empty elements in [source_begin, source_end(
+     * An insert in the middle needs both halves of this. Everything landing past the old end goes
+     * into raw storage and has to be constructed, everything before it lands on an element that is
+     * still there and can be assigned over, which is the whole point: assigning is what keeps a
+     * gap of raw memory from ever existing inside size(). Types like std::string would rather be
+     * assigned to anyway, they can answer it out of the buffer they already hold.
      */
-    static void shift_right(T* source_begin, T* source_end, T* target_begin) {
-        if (source_begin == target_begin) {
-            // Shifting by zero. Not just a shortcut: std::move_backward below would be called with
-            // its destination equal to its source end, which it explicitly does not allow, and it
-            // would self-move-assign every element in the range. See issue #65.
-            return;
+    template <typename It>
+    struct place_range {
+        It source;
+
+        void construct(T* dst, size_t offset, size_t n) const {
+            std::uninitialized_copy_n(std::next(source, static_cast<ptrdiff_t>(offset)), n, dst);
         }
 
-        // 1. uninitialized moves
-        auto const num_moves = std::distance(source_begin, source_end);
-        auto const target_end = target_begin + num_moves;
-        auto const num_uninitialized_move = (std::min)(num_moves, std::distance(source_end, target_end));
-        std::uninitialized_move(source_end - num_uninitialized_move, source_end, target_end - num_uninitialized_move);
-        std::move_backward(source_begin, source_end - num_uninitialized_move, target_end - num_uninitialized_move);
-        std::destroy(source_begin, (std::min)(source_end, target_begin));
+        void assign(T* dst, size_t offset, size_t n) const {
+            std::copy_n(std::next(source, static_cast<ptrdiff_t>(offset)), n, dst);
+        }
+    };
+
+    /**
+     * @brief Same, for count copies of one value.
+     */
+    struct place_copies {
+        T const& value;
+
+        void construct(T* dst, size_t /*offset*/, size_t n) const {
+            std::uninitialized_fill_n(dst, n, value);
+        }
+
+        void assign(T* dst, size_t /*offset*/, size_t n) const {
+            std::fill_n(dst, n, value);
+        }
+    };
+
+    /**
+     * @brief Places a single element by moving it out of source, which the caller owns.
+     */
+    static auto place_moved(T& source) -> place_range<std::move_iterator<T*>> {
+        return {std::make_move_iterator(std::addressof(source))};
     }
 
-    template <direction D>
-    [[nodiscard]] auto make_uninitialized_space_new(size_t s, T* p, size_t count) -> T* {
-        auto target = svector();
-        // we know target is indirect because we're increasing capacity
-        target.reserve(s + count);
-
-        // move everything [begin, pos[
-        auto* target_pos = std::uninitialized_move(data<D>(), p, target.template data<direction::indirect>());
-
-        // move everything [pos, end]
-        std::uninitialized_move(p, data<D>() + s, target_pos + count);
-
-        target.template set_size<direction::indirect>(s + count);
-        *this = std::move(target);
-        return target_pos;
-    }
-
-    template <direction D>
-    [[nodiscard]] auto make_uninitialized_space(T const* pos, size_t count) -> T* {
+    /**
+     * @brief Inserts count elements at pos, taken from place. Returns the first one.
+     *
+     * Invalidates every reference into the container: the elements from pos on are either shifted
+     * right or moved into a fresh allocation. A T const& argument that might be one of our own
+     * elements has to be dealt with first, see is_reference_into_self().
+     *
+     * There is deliberately no point in here where size() counts memory that holds no element.
+     * Opening a hole first and constructing into it afterwards was simpler, but it made the
+     * container undestroyable for as long as the hole lasted, so every constructor that could throw
+     * needed a rollback to close it again -- and getting that rollback right is what issues #68 and
+     * #74 were about. Threading the new elements through the shift instead, the way std::vector
+     * does, removes the hole and the rollback and the whole family of problems with them.
+     *
+     * What that costs is the strong exception guarantee for a partly done insert: an element
+     * assignment throwing part way leaves the container with the right number of elements but no
+     * promise about which. That is what the standard allows for insert, and what std::vector does.
+     * Where nothing has to be shifted over live elements the insert still either happens or does
+     * not: growing builds the result in a separate allocation, and single element inserts go
+     * through emplace(), which builds the element before touching anything.
+     */
+    template <direction D, typename Place>
+    auto insert_n(T const* pos, size_t count, Place const& place) -> T* {
         auto* const p = const_cast<T*>(pos); // NOLINT(cppcoreguidelines-pro-type-const-cast)
-        auto s = size<D>();
+        auto const s = size<D>();
+
+        if (count == 0) {
+            // Not just a shortcut: the shift below would be handed a destination equal to its
+            // source end, which std::move_backward does not allow, and it would self-move-assign
+            // every element it covers. See issue #65.
+            return p;
+        }
 
         // Both written as subtractions so neither can wrap: s <= max_size() and s <= capacity()
         // always hold. It used to say s + count > capacity(), which overflowed for a huge count,
@@ -623,83 +687,67 @@ class svector {
         }
 
         if (count > capacity<D>() - s) {
-            return make_uninitialized_space_new<D>(s, p, count);
+            return insert_n_new<D>(p, s, count, place);
         }
 
-        shift_right(p, data<D>() + s, p + count);
-        set_size<D>(s + count);
-        return p;
-    }
+        auto* const old_end = data<D>() + s;
+        auto const tail = static_cast<size_t>(old_end - p);
 
-    // makes space for uninitialized data of cout elements. Also updates size.
-    //
-    // Invalidates every reference into the container: the elements from pos onwards are either
-    // shifted right or moved into a fresh allocation. A T const& argument that might be one of
-    // our own elements has to be copied out of the way first, see is_reference_into_self().
-    //
-    // size() already counts the gap when this returns, so between here and the caller filling it
-    // the container is claiming raw memory. Whoever constructs into the gap has to call
-    // close_gap() if that throws, see issue #68.
-    [[nodiscard]] auto make_uninitialized_space(T const* pos, size_t count) -> T* {
-        if (is_direct()) {
-            return make_uninitialized_space<direction::direct>(pos, count);
-        }
-        return make_uninitialized_space<direction::indirect>(pos, count);
-    }
-
-    /**
-     * @brief Makes room for count elements at pos and has fill construct them into it.
-     *
-     * fill(p) has to construct all count elements at p, or none: the standard uninitialized_*
-     * algorithms clean up after themselves, and a single placement new either works or builds
-     * nothing. If it throws, the gap is closed again before the exception continues.
-     */
-    template <typename Fill>
-    auto fill_uninitialized_space(T const* pos, size_t count, Fill fill) -> T* {
-        auto* p = make_uninitialized_space(pos, count);
-        try {
-            fill(p);
-        } catch (...) {
-            close_gap(p, count);
-            throw;
-        }
-        return p;
-    }
-
-    /**
-     * @brief Undoes a make_uninitialized_space() whose gap could not be filled.
-     *
-     * Precondition: nothing is constructed in [gap_begin, gap_begin + count). The standard
-     * algorithms used to fill it destroy whatever they managed to build before rethrowing, and a
-     * single placement new either succeeds or constructs nothing.
-     *
-     * Runs while an exception is in flight, so it must not throw itself. When relocating a T
-     * cannot throw we shift the tail back down and end up with exactly the elements we started
-     * with. Otherwise the only safe thing left is to drop the tail, which still leaves a container
-     * that is valid and destroys cleanly, just shorter. std::move_if_noexcept, which is how one
-     * would normally keep the elements of a throwing-move type, is not available here: falling
-     * back to a copy could throw a second exception during unwinding and call std::terminate.
-     */
-    void close_gap(T* gap_begin, size_t count) noexcept {
-        auto* const first = data();
-        auto* const last = first + size();
-        auto* const tail = gap_begin + count;
-
-        if constexpr (std::is_nothrow_move_constructible_v<T> && std::is_nothrow_move_assignable_v<T>) {
-            // Mirror image of shift_right: the destination starts with the raw gap, which has to
-            // be constructed into, and only what lands past it can be assigned.
-            auto const tail_size = static_cast<size_t>(last - tail);
-            auto const num_uninitialized_move = (std::min)(count, tail_size);
-            std::uninitialized_move_n(tail, num_uninitialized_move, gap_begin);
-            std::move(tail + num_uninitialized_move, last, gap_begin + num_uninitialized_move);
-
-            // whatever the shift did not overwrite is moved-from but still alive
-            std::destroy((std::max)(gap_begin + tail_size, tail), last);
-            set_size(size() - count);
+        if (tail > count) {
+            // The tail is long enough that shifting it right stays within the old elements plus
+            // the count raw slots behind them, so all the new elements land on live ones.
+            std::uninitialized_move(old_end - count, old_end, old_end);
+            set_size<D>(s + count);
+            std::move_backward(p, old_end - count, old_end);
+            place.assign(p, 0, count);
         } else {
-            std::destroy(tail, last);
-            set_size(static_cast<size_t>(gap_begin - first));
+            // The tail clears the ground it stood on, so the new elements behind the old end have
+            // nothing under them and are built instead.
+            place.construct(old_end, tail, count - tail);
+            set_size<D>(s + count - tail);
+            std::uninitialized_move(p, old_end, p + count);
+            set_size<D>(s + count);
+            place.assign(p, 0, tail);
         }
+        return p;
+    }
+
+    /**
+     * @brief insert_n() for when the elements no longer fit. Builds the result in fresh storage.
+     */
+    template <direction D, typename Place>
+    auto insert_n_new(T* p, size_t s, size_t count, Place const& place) -> T* {
+        auto target = svector();
+        target.reserve(s + count); // we know target is indirect because we're increasing capacity
+
+        auto* const dst = target.template data<direction::indirect>();
+        auto* const gap = dst + (p - data<D>());
+
+        // The new elements before ours: nothing of ours has moved yet if this throws, so the insert
+        // simply has not happened, and place can still read the elements we hold.
+        place.construct(gap, 0, count);
+
+        // What is built now is the gap but nothing in front of it, and no size can say that, so for
+        // as long as the hole lasts the cleanup is spelled out here. Leaving it to target's
+        // destructor, which sees a size of zero, is what leaked the relocated elements in issue
+        // #74. Both moves below destroy whatever they managed to build themselves.
+        auto guard = detail::destroy_guard<T>(gap, gap + count);
+        std::uninitialized_move(data<D>(), p, dst);
+        guard.extend_front(dst);
+        std::uninitialized_move(p, data<D>() + s, gap + count);
+        guard.release();
+
+        target.template set_size<direction::indirect>(s + count);
+        *this = std::move(target);
+        return gap;
+    }
+
+    template <typename Place>
+    auto insert_n(T const* pos, size_t count, Place const& place) -> T* {
+        if (is_direct()) {
+            return insert_n<direction::direct>(pos, count, place);
+        }
+        return insert_n<direction::indirect>(pos, count, place);
     }
 
     void destroy() {
@@ -1097,45 +1145,30 @@ public:
         // dangling. Build the element first. Inserting in the middle already moves every
         // element after pos, so one extra move does not change the cost.
         auto tmp = T(std::forward<Args>(args)...);
-        return fill_uninitialized_space(pos, 1, [&](T* p) {
-            new (static_cast<void*>(p)) T(std::move(tmp));
-        });
+        return insert_n(pos, 1, place_moved(tmp));
     }
 
+    // Both of these build the element before anything is shifted, which is what emplace() does, so
+    // they go there. It costs one move, and it is what makes a single element insert either happen
+    // or not happen at all: the copy is the only part that can throw, and by the time anything has
+    // been touched it is already done. It also means value is allowed to be one of our own
+    // elements, without a copy to get it out of the way first.
     auto insert(const_iterator pos, T const& value) -> iterator {
-        if (is_reference_into_self(value)) {
-            // making space moves our elements around, so value has to be copied out of the
-            // way first. v.insert(v.begin(), v[0])
-            auto const tmp = value;
-            return insert(pos, tmp);
-        }
-        // not aliasing, so we can make space first and construct straight into it. Going
-        // through emplace() would build a temporary and then move it, for no reason.
-        return fill_uninitialized_space(pos, 1, [&](T* p) {
-            new (static_cast<void*>(p)) T(value);
-        });
+        return emplace(pos, value);
     }
 
     auto insert(const_iterator pos, T&& value) -> iterator {
-        if (is_reference_into_self(value)) {
-            auto tmp = std::move(value);
-            return insert(pos, std::move(tmp));
-        }
-        return fill_uninitialized_space(pos, 1, [&](T* p) {
-            new (static_cast<void*>(p)) T(std::move(value));
-        });
+        return emplace(pos, std::move(value));
     }
 
     auto insert(const_iterator pos, size_t count, T const& value) -> iterator {
         if (is_reference_into_self(value)) {
-            // making space moves our elements around, so value has to be copied out of the
-            // way first. v.insert(v.begin(), 1000, v[0])
+            // the shift moves our elements around and assigns over them, so value has to be
+            // copied out of the way first. v.insert(v.begin(), 1000, v[0])
             auto const tmp = value;
             return insert(pos, count, tmp);
         }
-        return fill_uninitialized_space(pos, count, [&](T* p) {
-            std::uninitialized_fill_n(p, count, value);
-        });
+        return insert_n(pos, count, place_copies{value});
     }
 
     template <typename It>
@@ -1161,9 +1194,7 @@ public:
     template <typename It>
     auto insert(const_iterator pos, It first, It last, std::forward_iterator_tag /*unused*/) -> iterator {
         auto const count = static_cast<size_t>(std::distance(first, last));
-        return fill_uninitialized_space(pos, count, [&](T* p) {
-            std::uninitialized_copy(first, last, p);
-        });
+        return insert_n(pos, count, place_range<It>{first});
     }
 
     template <typename InputIt, typename = detail::enable_if_t<detail::is_input_iterator<InputIt>>>

--- a/include/ankerl/svector.h
+++ b/include/ankerl/svector.h
@@ -188,9 +188,9 @@ struct storage : public header {
 /**
  * @brief Destroys [first, last) on the way out, unless it has been released.
  *
- * A half built container can normally describe what it has by its size, and then its own destructor
- * is all the cleanup that is needed. This is for the one place where the constructed part is not a
- * prefix, so no size can express it.
+ * Half built storage can normally say what it holds with a size, and then a destructor is all the
+ * cleanup anyone needs. This is for the one place where the built part is not a prefix, so no size
+ * can express it. Deleting the copy is what keeps it from being handed around and destroying twice.
  */
 template <typename T>
 class destroy_guard {
@@ -203,9 +203,7 @@ public:
         , m_last(last) {}
 
     destroy_guard(destroy_guard const&) = delete;
-    destroy_guard(destroy_guard&&) = delete;
     auto operator=(destroy_guard const&) -> destroy_guard& = delete;
-    auto operator=(destroy_guard&&) -> destroy_guard& = delete;
 
     ~destroy_guard() {
         std::destroy(m_first, m_last);
@@ -307,9 +305,14 @@ class svector {
     /**
      * @brief True when value is one of our own elements, e.g. from v.push_back(v[0]).
      *
-     * Growing or shifting moves those elements around and destroys the originals, so anything
-     * that takes a T const& has to copy it out of the way first. Compared as uintptr_t because
-     * relational operators on pointers into different objects are not specified.
+     * Growing or shifting moves those elements around and assigns over them, so a caller taking a
+     * T const& has to get it out of the way before that starts. There are two ways to do that and
+     * only one of them needs this: either copy value to the stack first, which is what the callers
+     * below do, or build the new element before touching anything, which is what emplace() does.
+     * insert(pos, value) takes the second route, which is why it does not ask.
+     *
+     * Compared as uintptr_t because relational operators on pointers into different objects are
+     * not specified.
      */
     [[nodiscard]] auto is_reference_into_self(T const& value) const -> bool {
         auto const p = reinterpret_cast<uintptr_t>(std::addressof(value));
@@ -602,13 +605,10 @@ class svector {
     }
 
     /**
-     * @brief How insert_n() puts new elements somewhere: source is a range of count of them.
+     * @brief Where insert_n() gets its new elements from: source is a range of count of them.
      *
-     * An insert in the middle needs both halves of this. Everything landing past the old end goes
-     * into raw storage and has to be constructed, everything before it lands on an element that is
-     * still there and can be assigned over, which is the whole point: assigning is what keeps a
-     * gap of raw memory from ever existing inside size(). Types like std::string would rather be
-     * assigned to anyway, they can answer it out of the buffer they already hold.
+     * construct() builds n of them, starting at the offset'th, into raw storage. assign() puts the
+     * first n onto elements that are already there. An insert needs both, see insert_n().
      */
     template <typename It>
     struct place_range {
@@ -618,8 +618,8 @@ class svector {
             std::uninitialized_copy_n(std::next(source, static_cast<ptrdiff_t>(offset)), n, dst);
         }
 
-        void assign(T* dst, size_t offset, size_t n) const {
-            std::copy_n(std::next(source, static_cast<ptrdiff_t>(offset)), n, dst);
+        void assign(T* dst, size_t n) const {
+            std::copy_n(source, n, dst);
         }
     };
 
@@ -633,14 +633,11 @@ class svector {
             std::uninitialized_fill_n(dst, n, value);
         }
 
-        void assign(T* dst, size_t /*offset*/, size_t n) const {
+        void assign(T* dst, size_t n) const {
             std::fill_n(dst, n, value);
         }
     };
 
-    /**
-     * @brief Places a single element by moving it out of source, which the caller owns.
-     */
     static auto place_moved(T& source) -> place_range<std::move_iterator<T*>> {
         return {std::make_move_iterator(std::addressof(source))};
     }
@@ -652,19 +649,21 @@ class svector {
      * right or moved into a fresh allocation. A T const& argument that might be one of our own
      * elements has to be dealt with first, see is_reference_into_self().
      *
-     * There is deliberately no point in here where size() counts memory that holds no element.
-     * Opening a hole first and constructing into it afterwards was simpler, but it made the
-     * container undestroyable for as long as the hole lasted, so every constructor that could throw
-     * needed a rollback to close it again -- and getting that rollback right is what issues #68 and
-     * #74 were about. Threading the new elements through the shift instead, the way std::vector
-     * does, removes the hole and the rollback and the whole family of problems with them.
+     * There is deliberately no point in here where size() counts memory that holds no element. What
+     * lands past the old end is constructed, what lands on an element that is still there is
+     * assigned over it, and size() only ever grows by a step that has already happened. Opening a
+     * hole and constructing into it afterwards was simpler, but it left the container undestroyable
+     * for as long as the hole lasted, so every constructor that could throw needed a rollback to
+     * close it again -- and getting that rollback right is what issues #68 and #74 were about.
      *
-     * What that costs is the strong exception guarantee for a partly done insert: an element
-     * assignment throwing part way leaves the container with the right number of elements but no
-     * promise about which. That is what the standard allows for insert, and what std::vector does.
-     * Where nothing has to be shifted over live elements the insert still either happens or does
-     * not: growing builds the result in a separate allocation, and single element inserts go
-     * through emplace(), which builds the element before touching anything.
+     * What it costs is the strong exception guarantee for an insert that has to assign over live
+     * elements: failing part way leaves the container with the right number of elements but no
+     * promise about which, and only the part before pos is certain to be untouched. That is what
+     * the standard asks of insert, and what std::vector does. The paths that assign over nothing
+     * are unaffected: growing builds the result in an allocation of its own, and a single element
+     * goes through emplace(), which builds it before anything is touched. Growing is all or nothing
+     * only as far as relocating a T is: a move constructor that throws part way through leaves our
+     * own elements moved from, and then all that is left is that nothing leaks.
      */
     template <direction D, typename Place>
     auto insert_n(T const* pos, size_t count, Place const& place) -> T* {
@@ -672,9 +671,9 @@ class svector {
         auto const s = size<D>();
 
         if (count == 0) {
-            // Not just a shortcut: the shift below would be handed a destination equal to its
-            // source end, which std::move_backward does not allow, and it would self-move-assign
-            // every element it covers. See issue #65.
+            // Not just a shortcut: the std::move_backward below would be handed a destination equal
+            // to its source end, which it does not allow, and it would self-move-assign every
+            // element it covers. See issue #65.
             return p;
         }
 
@@ -687,7 +686,7 @@ class svector {
         }
 
         if (count > capacity<D>() - s) {
-            return insert_n_new<D>(p, s, count, place);
+            return insert_n_new<D>(p, count, place);
         }
 
         auto* const old_end = data<D>() + s;
@@ -699,7 +698,7 @@ class svector {
             std::uninitialized_move(old_end - count, old_end, old_end);
             set_size<D>(s + count);
             std::move_backward(p, old_end - count, old_end);
-            place.assign(p, 0, count);
+            place.assign(p, count);
         } else {
             // The tail clears the ground it stood on, so the new elements behind the old end have
             // nothing under them and are built instead.
@@ -707,7 +706,7 @@ class svector {
             set_size<D>(s + count - tail);
             std::uninitialized_move(p, old_end, p + count);
             set_size<D>(s + count);
-            place.assign(p, 0, tail);
+            place.assign(p, tail);
         }
         return p;
     }
@@ -716,7 +715,8 @@ class svector {
      * @brief insert_n() for when the elements no longer fit. Builds the result in fresh storage.
      */
     template <direction D, typename Place>
-    auto insert_n_new(T* p, size_t s, size_t count, Place const& place) -> T* {
+    auto insert_n_new(T* p, size_t count, Place const& place) -> T* {
+        auto const s = size<D>();
         auto target = svector();
         target.reserve(s + count); // we know target is indirect because we're increasing capacity
 
@@ -1148,11 +1148,8 @@ public:
         return insert_n(pos, 1, place_moved(tmp));
     }
 
-    // Both of these build the element before anything is shifted, which is what emplace() does, so
-    // they go there. It costs one move, and it is what makes a single element insert either happen
-    // or not happen at all: the copy is the only part that can throw, and by the time anything has
-    // been touched it is already done. It also means value is allowed to be one of our own
-    // elements, without a copy to get it out of the way first.
+    // Both of these want the element built before anything is shifted, which is what emplace()
+    // does, so they go there rather than say it again. See insert_n() for what that buys.
     auto insert(const_iterator pos, T const& value) -> iterator {
         return emplace(pos, value);
     }

--- a/test/unit/insert.cpp
+++ b/test/unit/insert.cpp
@@ -216,9 +216,9 @@ TEST_CASE("insert_nothing_keeps_the_elements_indirect") {
     assert_eq(vec, sv);
 }
 
-// make_uninitialized_space() decided whether the elements still fit with "s + count >
-// capacity()". A huge count wrapped that sum around to something small, so the check said yes and
-// the in place shift wrote past the end of the buffer. See issue #69.
+// insert_n() decides whether the elements still fit. It used to ask "s + count > capacity()", and a
+// huge count wrapped that sum around to something small, so the check said yes and the in place
+// shift wrote past the end of the buffer. See issue #69.
 TEST_CASE("insert_count_too_large_throws") {
     auto const huge = (std::numeric_limits<size_t>::max)();
 

--- a/test/unit/insert_exception_safety.cpp
+++ b/test/unit/insert_exception_safety.cpp
@@ -8,8 +8,9 @@
 // get wrong: whatever throws, and whenever, it finds a container that is a container.
 //
 // What that is worth differs by path, and these tests pin down which is which:
-//  * growing builds the result in a separate allocation, so a throw leaves the original alone
-//  * a single element is built by emplace() before anything moves, same thing
+//  * growing builds the result in a separate allocation, so a failed copy leaves the original
+//    alone -- though a failed move cannot, it has already emptied what it was reading
+//  * a single element is built by emplace() before anything moves, so that one is all or nothing
 //  * an in place insert of several has to assign the new values over elements that are still
 //    there, and once one of those fails there is no way back. All that is left then is the basic
 //    guarantee, which is also all the standard asks of std::vector: the container is valid, and
@@ -29,21 +30,31 @@
 
 namespace {
 
+// The types below all fail the same way: every operation that can throw spends from one budget, and
+// the throw lands on the operation that finds it empty. Only one of them is ever in play at a time,
+// so a single counter says everything four of them would.
+int budget = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+void tick(char const* what) {
+    if (--budget < 0) {
+        throw std::runtime_error(what);
+    }
+}
+
+// never runs out, for setting up a container before the interesting part
+constexpr auto unlimited = 1000000;
+
 // Copying throws once the budget runs out, moving never does. This is the ordinary case: a type
 // whose copy can fail because it allocates, like std::string.
 struct ThrowOnCopy {
     std::string value;
-
-    static int budget; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
     explicit ThrowOnCopy(std::string v)
         : value(std::move(v)) {}
 
     ThrowOnCopy(ThrowOnCopy const& other)
         : value(other.value) {
-        if (--budget < 0) {
-            throw std::runtime_error("copy");
-        }
+        tick("copy");
     }
 
     ThrowOnCopy(ThrowOnCopy&&) noexcept = default;
@@ -51,48 +62,34 @@ struct ThrowOnCopy {
     // an insert copies a new element either way, into a raw slot or over a live one, so the budget
     // has to cover both or half the paths through insert_n() never see a failure
     auto operator=(ThrowOnCopy const& other) -> ThrowOnCopy& {
-        if (--budget < 0) {
-            throw std::runtime_error("copy assign");
-        }
+        tick("copy assign");
         value = other.value;
         return *this;
     }
 
     auto operator=(ThrowOnCopy&&) noexcept -> ThrowOnCopy& = default;
     ~ThrowOnCopy() = default;
-
-    auto operator==(ThrowOnCopy const& other) const -> bool {
-        return value == other.value;
-    }
 };
-
-int ThrowOnCopy::budget = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 static_assert(std::is_nothrow_move_constructible_v<ThrowOnCopy>);
 static_assert(std::is_nothrow_move_assignable_v<ThrowOnCopy>);
 
 // Same, but relocating it can throw too. That used to mean the tail could not be shifted back and
-// was dropped instead; now the new elements are built before anything moves, so this type gets the
-// same rollback as the one above.
+// was dropped instead. Nothing about the insert depends on what the move constructor promises any
+// more, so this type is treated exactly like the one above.
 struct ThrowOnCopyAndMove {
     std::string value;
-
-    static int budget; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
     explicit ThrowOnCopyAndMove(std::string v)
         : value(std::move(v)) {}
 
     ThrowOnCopyAndMove(ThrowOnCopyAndMove const& other)
         : value(other.value) {
-        if (--budget < 0) {
-            throw std::runtime_error("copy");
-        }
+        tick("copy");
     }
 
     auto operator=(ThrowOnCopyAndMove const& other) -> ThrowOnCopyAndMove& {
-        if (--budget < 0) {
-            throw std::runtime_error("copy assign");
-        }
+        tick("copy assign");
         value = other.value;
         return *this;
     }
@@ -109,16 +106,12 @@ struct ThrowOnCopyAndMove {
     ~ThrowOnCopyAndMove() = default;
 };
 
-int ThrowOnCopyAndMove::budget = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
 static_assert(!std::is_nothrow_move_constructible_v<ThrowOnCopyAndMove>);
 
 // Moving throws once the budget runs out. Only reachable while growing, where the elements have to
 // be relocated into the new storage, and the one case that can leave us short of a full rollback.
 struct ThrowOnMove {
     std::string value;
-
-    static int budget; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
     explicit ThrowOnMove(std::string v)
         : value(std::move(v)) {}
@@ -128,9 +121,7 @@ struct ThrowOnMove {
     // NOLINTNEXTLINE(performance-noexcept-move-constructor)
     ThrowOnMove(ThrowOnMove&& other)
         : value(std::move(other.value)) {
-        if (--budget < 0) {
-            throw std::runtime_error("move");
-        }
+        tick("move");
     }
 
     auto operator=(ThrowOnMove const&) -> ThrowOnMove& = default;
@@ -142,13 +133,9 @@ struct ThrowOnMove {
     ~ThrowOnMove() = default;
 };
 
-int ThrowOnMove::budget = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-// Assigning throws once the budget runs out, which is what the rotation into place does.
+// Assigning throws once the budget runs out, which is what shifting the tail right does.
 struct ThrowOnMoveAssign {
     std::string value;
-
-    static int budget; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
     explicit ThrowOnMoveAssign(std::string v)
         : value(std::move(v)) {}
@@ -159,16 +146,12 @@ struct ThrowOnMoveAssign {
 
     // NOLINTNEXTLINE(performance-noexcept-move-constructor)
     auto operator=(ThrowOnMoveAssign&& other) -> ThrowOnMoveAssign& {
-        if (--budget < 0) {
-            throw std::runtime_error("move assign");
-        }
+        tick("move assign");
         value = std::move(other.value);
         return *this;
     }
     ~ThrowOnMoveAssign() = default;
 };
-
-int ThrowOnMoveAssign::budget = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 template <typename V>
 auto make(size_t count) -> V {
@@ -191,17 +174,32 @@ auto contents(V const& v) -> std::vector<std::string> {
 using SvCopy = ankerl::svector<ThrowOnCopy, 4>;
 
 /**
- * @brief Checks what a failed insert at pos still has to be, in every case.
+ * @brief Runs an insert of count elements at pos that has to throw, and checks what is left.
  *
- * Nothing in front of pos is ever read or written by an insert, so it has to come out exactly as
- * it went in, and everything from pos on has to at least be readable -- which is asan's business
- * rather than the comparison's. The count is either the old one or the full new one: the new
- * elements are counted in one step each, never half way through one.
+ * grows says the insert had to reallocate, and then the answer is simple: it was built in an
+ * allocation of its own which is just dropped again, so nothing happened at all.
+ *
+ * In place there is no way back once an assignment over a live element has failed, and what is
+ * promised is only this. Nothing in front of pos is ever read or written by an insert, so it comes
+ * out exactly as it went in. Everything from pos on has to at least be readable, which is asan's
+ * business rather than the comparison's. And the count is either the old one or the full new one:
+ * the new elements are counted in one step each, never half way through one.
  */
-void require_valid_after_throw(std::vector<std::string> const& before,
-                               std::vector<std::string> const& after,
-                               size_t pos,
-                               size_t count) {
+template <typename Vec, typename Insert>
+void require_throws_and_stays_valid(Vec& v, size_t pos, size_t count, int throw_at, Insert insert) {
+    auto const before = contents(v);
+    auto const grows = count > v.capacity() - v.size();
+
+    budget = throw_at;
+    REQUIRE_THROWS_AS(insert(v), std::runtime_error);
+    budget = unlimited;
+
+    auto const after = contents(v);
+    if (grows) {
+        REQUIRE(after == before);
+        return;
+    }
+
     REQUIRE((after.size() == before.size() || after.size() == before.size() + count));
     REQUIRE(after.size() >= pos);
     for (size_t i = 0; i < pos; ++i) {
@@ -223,21 +221,11 @@ TEST_CASE("insert_count_throwing_copy_keeps_container_valid") {
             for (size_t count = 1; count <= 5; ++count) {
                 // every copy the insert makes is a place the failure can land, and which of them
                 // are into raw slots and which onto live ones depends on all three loops
-                for (size_t throw_at = 0; throw_at < count; ++throw_at) {
+                for (int throw_at = 0; throw_at < static_cast<int>(count); ++throw_at) {
                     auto v = make<SvCopy>(size);
-                    auto const before = contents(v);
-                    auto const grows = count > v.capacity() - v.size();
-
-                    ThrowOnCopy::budget = static_cast<int>(throw_at);
-                    REQUIRE_THROWS_AS(v.insert(v.cbegin() + pos, count, filler), std::runtime_error);
-                    ThrowOnCopy::budget = 1000000;
-
-                    if (grows) {
-                        // built in an allocation of its own, which is simply dropped again
-                        REQUIRE(contents(v) == before);
-                    } else {
-                        require_valid_after_throw(before, contents(v), pos, count);
-                    }
+                    require_throws_and_stays_valid(v, pos, count, throw_at, [&](SvCopy& c) {
+                        c.insert(c.cbegin() + pos, count, filler);
+                    });
                 }
             }
         }
@@ -253,20 +241,11 @@ TEST_CASE("insert_range_throwing_copy_keeps_container_valid") {
 
     for (size_t size = 0; size <= 9; ++size) {
         for (size_t pos = 0; pos <= size; ++pos) {
-            for (size_t throw_at = 0; throw_at < source.size(); ++throw_at) {
+            for (int throw_at = 0; throw_at < static_cast<int>(source.size()); ++throw_at) {
                 auto v = make<SvCopy>(size);
-                auto const before = contents(v);
-                auto const grows = source.size() > v.capacity() - v.size();
-
-                ThrowOnCopy::budget = static_cast<int>(throw_at);
-                REQUIRE_THROWS_AS(v.insert(v.cbegin() + pos, source.begin(), source.end()), std::runtime_error);
-                ThrowOnCopy::budget = 1000000;
-
-                if (grows) {
-                    REQUIRE(contents(v) == before);
-                } else {
-                    require_valid_after_throw(before, contents(v), pos, source.size());
-                }
+                require_throws_and_stays_valid(v, pos, source.size(), throw_at, [&](SvCopy& c) {
+                    c.insert(c.cbegin() + pos, source.begin(), source.end());
+                });
             }
         }
     }
@@ -283,9 +262,9 @@ TEST_CASE("insert_single_throwing_copy_keeps_container_intact") {
             auto v = make<SvCopy>(size);
             auto const before = contents(v);
 
-            ThrowOnCopy::budget = 0;
+            budget = 0;
             REQUIRE_THROWS_AS(v.insert(v.cbegin() + pos, filler), std::runtime_error);
-            ThrowOnCopy::budget = 1000000;
+            budget = unlimited;
 
             REQUIRE(contents(v) == before);
         }
@@ -300,9 +279,9 @@ TEST_CASE("emplace_throwing_copy_keeps_container_intact") {
             auto v = make<SvCopy>(size);
             auto const before = contents(v);
 
-            ThrowOnCopy::budget = 0;
+            budget = 0;
             REQUIRE_THROWS_AS(v.emplace(v.cbegin() + pos, filler), std::runtime_error);
-            ThrowOnCopy::budget = 1000000;
+            budget = unlimited;
 
             REQUIRE(contents(v) == before);
         }
@@ -319,21 +298,13 @@ TEST_CASE("insert_throwing_copy_of_a_throwing_move_type_keeps_container_valid") 
     for (size_t size = 0; size <= 9; ++size) {
         for (size_t pos = 0; pos <= size; ++pos) {
             for (size_t count = 1; count <= 3; ++count) {
-                ThrowOnCopyAndMove::budget = 1000000;
+                budget = unlimited;
                 auto v = make<Vec>(size);
-                auto const before = contents(v);
                 auto const filler = ThrowOnCopyAndMove(std::string(40, 'z'));
-                auto const grows = count > v.capacity() - v.size();
 
-                ThrowOnCopyAndMove::budget = 0;
-                REQUIRE_THROWS_AS(v.insert(v.cbegin() + pos, count, filler), std::runtime_error);
-                ThrowOnCopyAndMove::budget = 1000000;
-
-                if (grows) {
-                    REQUIRE(contents(v) == before);
-                } else {
-                    require_valid_after_throw(before, contents(v), pos, count);
-                }
+                require_throws_and_stays_valid(v, pos, count, 0, [&](Vec& c) {
+                    c.insert(c.cbegin() + pos, count, filler);
+                });
             }
         }
     }
@@ -348,7 +319,7 @@ TEST_CASE("insert_throwing_move_while_growing_does_not_leak") {
 
     // filled to the brim, so the insert below has no choice but to grow
     auto make_full = [](size_t at_least) {
-        ThrowOnMove::budget = 1000000;
+        budget = unlimited;
         auto v = make<Vec>(at_least);
         while (v.size() < v.capacity()) {
             v.emplace_back(std::string(40, 'q'));
@@ -362,13 +333,13 @@ TEST_CASE("insert_throwing_move_while_growing_does_not_leak") {
             // relocating is exactly one move per element, and every one of them is a place the
             // throw can land: while the front is still a hole, while the tail is going over, and
             // everywhere in between
-            for (size_t budget = 0; budget < full; ++budget) {
+            for (size_t spend = 0; spend < full; ++spend) {
                 auto v = make_full(at_least);
                 auto const filler = ThrowOnMove(std::string(40, 'z'));
 
-                ThrowOnMove::budget = static_cast<int>(budget);
+                budget = static_cast<int>(spend);
                 REQUIRE_THROWS_AS(v.insert(v.cbegin() + pos, filler), std::runtime_error);
-                ThrowOnMove::budget = 1000000;
+                budget = unlimited;
 
                 // we never got far enough to adopt the new storage, so our own elements are still
                 // ours and still all there. Some have been moved from, so the count is all that
@@ -379,36 +350,36 @@ TEST_CASE("insert_throwing_move_while_growing_does_not_leak") {
     }
 }
 
-// The rotation into place is the one step that assigns, so it is the one step a throwing move
+// Shifting the tail right is the one step that move assigns, so it is the one step a throwing move
 // assignment can interrupt. Everything it touches is a live object either way, so the container
 // stays valid and destructible, just with the elements in an order nobody promised.
 TEST_CASE("insert_throwing_move_assign_leaves_a_valid_container") {
     using Vec = ankerl::svector<ThrowOnMoveAssign, 8>;
     auto num_throws = 0;
 
-    // one short of the inline capacity, so the insert stays in place and does rotate
+    // inside the inline capacity, so the insert stays in place and does shift
     for (size_t size = 1; size <= 7; ++size) {
         for (size_t pos = 0; pos < size; ++pos) {
-            // how many assignments a rotation takes is std::rotate's business, so sweep past it
-            for (size_t budget = 0; budget <= size + 1; ++budget) {
-                ThrowOnMoveAssign::budget = 1000000;
+            // the number of assignments depends on where pos falls, so sweep past the end of it
+            for (size_t spend = 0; spend <= size + 1; ++spend) {
+                budget = unlimited;
                 auto v = make<Vec>(size);
                 auto const filler = ThrowOnMoveAssign(std::string(40, 'z'));
 
-                ThrowOnMoveAssign::budget = static_cast<int>(budget);
+                budget = static_cast<int>(spend);
                 try {
                     v.insert(v.cbegin() + pos, filler);
                 } catch (std::runtime_error const&) {
                     ++num_throws;
                 }
-                ThrowOnMoveAssign::budget = 1000000;
+                budget = unlimited;
 
-                // the new element was built and counted before the rotation started, so it is
-                // part of the container whether or not it ever reached pos
+                // the tail is moved out to its new place and counted before anything is assigned,
+                // so the element is part of the container whether or not it ever reached pos
                 REQUIRE(v.size() == size + 1);
 
                 // reading every one of them is the actual check, asan is what answers it. Their
-                // values are whatever a half done rotation left, and a moved from string can be
+                // values are whatever a half done shift left, and a moved from string can be
                 // anything valid, so there is nothing to compare against.
                 for (auto const& e : v) {
                     REQUIRE(e.value.size() <= 40);

--- a/test/unit/insert_exception_safety.cpp
+++ b/test/unit/insert_exception_safety.cpp
@@ -1,10 +1,19 @@
-// Tests for https://github.com/martinus/svector/issues/68
+// Tests for what an insert leaves behind when constructing, moving or assigning a T throws.
+// Originally https://github.com/martinus/svector/issues/68, extended by #74.
 //
-// make_uninitialized_space() shifts the elements from pos out of the way and immediately counts
-// the resulting gap in size(). Until the caller has constructed into that gap the container is
-// claiming raw memory, so a throwing element constructor used to leave it in a state that could
-// not even be destroyed: the destructor ran over slots that were never built, or over slots the
-// filling algorithm had already cleaned up, which is a double destroy.
+// Making space used to shift the elements from pos out of the way and immediately count the
+// resulting gap in size(). Until the caller had constructed into that gap the container was
+// claiming raw memory, so a throwing element constructor left it in a state that could not even be
+// destroyed. insert_n() threads the new elements through the shift instead, so there is no gap to
+// get wrong: whatever throws, and whenever, it finds a container that is a container.
+//
+// What that is worth differs by path, and these tests pin down which is which:
+//  * growing builds the result in a separate allocation, so a throw leaves the original alone
+//  * a single element is built by emplace() before anything moves, same thing
+//  * an in place insert of several has to assign the new values over elements that are still
+//    there, and once one of those fails there is no way back. All that is left then is the basic
+//    guarantee, which is also all the standard asks of std::vector: the container is valid, and
+//    everything before pos is still untouched.
 //
 // Run under asan, the failures here are use-after-free and leaks rather than wrong values.
 
@@ -38,7 +47,17 @@ struct ThrowOnCopy {
     }
 
     ThrowOnCopy(ThrowOnCopy&&) noexcept = default;
-    auto operator=(ThrowOnCopy const&) -> ThrowOnCopy& = default;
+
+    // an insert copies a new element either way, into a raw slot or over a live one, so the budget
+    // has to cover both or half the paths through insert_n() never see a failure
+    auto operator=(ThrowOnCopy const& other) -> ThrowOnCopy& {
+        if (--budget < 0) {
+            throw std::runtime_error("copy assign");
+        }
+        value = other.value;
+        return *this;
+    }
+
     auto operator=(ThrowOnCopy&&) noexcept -> ThrowOnCopy& = default;
     ~ThrowOnCopy() = default;
 
@@ -52,8 +71,9 @@ int ThrowOnCopy::budget = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-
 static_assert(std::is_nothrow_move_constructible_v<ThrowOnCopy>);
 static_assert(std::is_nothrow_move_assignable_v<ThrowOnCopy>);
 
-// Same, but relocating it can throw too, so the container cannot shift the tail back and has to
-// fall back to dropping it. All that is promised then is that nothing leaks.
+// Same, but relocating it can throw too. That used to mean the tail could not be shifted back and
+// was dropped instead; now the new elements are built before anything moves, so this type gets the
+// same rollback as the one above.
 struct ThrowOnCopyAndMove {
     std::string value;
 
@@ -69,11 +89,18 @@ struct ThrowOnCopyAndMove {
         }
     }
 
+    auto operator=(ThrowOnCopyAndMove const& other) -> ThrowOnCopyAndMove& {
+        if (--budget < 0) {
+            throw std::runtime_error("copy assign");
+        }
+        value = other.value;
+        return *this;
+    }
+
     // NOLINTNEXTLINE(performance-noexcept-move-constructor)
     ThrowOnCopyAndMove(ThrowOnCopyAndMove&& other)
         : value(std::move(other.value)) {}
 
-    auto operator=(ThrowOnCopyAndMove const&) -> ThrowOnCopyAndMove& = default;
     // NOLINTNEXTLINE(performance-noexcept-move-constructor)
     auto operator=(ThrowOnCopyAndMove&& other) -> ThrowOnCopyAndMove& {
         value = std::move(other.value);
@@ -86,15 +113,74 @@ int ThrowOnCopyAndMove::budget = 0; // NOLINT(cppcoreguidelines-avoid-non-const-
 
 static_assert(!std::is_nothrow_move_constructible_v<ThrowOnCopyAndMove>);
 
-auto make(size_t count) -> ankerl::svector<ThrowOnCopy, 4> {
-    auto v = ankerl::svector<ThrowOnCopy, 4>();
+// Moving throws once the budget runs out. Only reachable while growing, where the elements have to
+// be relocated into the new storage, and the one case that can leave us short of a full rollback.
+struct ThrowOnMove {
+    std::string value;
+
+    static int budget; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+    explicit ThrowOnMove(std::string v)
+        : value(std::move(v)) {}
+
+    ThrowOnMove(ThrowOnMove const& other) = default;
+
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    ThrowOnMove(ThrowOnMove&& other)
+        : value(std::move(other.value)) {
+        if (--budget < 0) {
+            throw std::runtime_error("move");
+        }
+    }
+
+    auto operator=(ThrowOnMove const&) -> ThrowOnMove& = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    auto operator=(ThrowOnMove&& other) -> ThrowOnMove& {
+        value = std::move(other.value);
+        return *this;
+    }
+    ~ThrowOnMove() = default;
+};
+
+int ThrowOnMove::budget = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+// Assigning throws once the budget runs out, which is what the rotation into place does.
+struct ThrowOnMoveAssign {
+    std::string value;
+
+    static int budget; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+    explicit ThrowOnMoveAssign(std::string v)
+        : value(std::move(v)) {}
+
+    ThrowOnMoveAssign(ThrowOnMoveAssign const&) = default;
+    ThrowOnMoveAssign(ThrowOnMoveAssign&&) noexcept = default;
+    auto operator=(ThrowOnMoveAssign const&) -> ThrowOnMoveAssign& = default;
+
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    auto operator=(ThrowOnMoveAssign&& other) -> ThrowOnMoveAssign& {
+        if (--budget < 0) {
+            throw std::runtime_error("move assign");
+        }
+        value = std::move(other.value);
+        return *this;
+    }
+    ~ThrowOnMoveAssign() = default;
+};
+
+int ThrowOnMoveAssign::budget = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+template <typename V>
+auto make(size_t count) -> V {
+    auto v = V();
     for (auto& s : make_long_strings(count)) {
         v.emplace_back(std::move(s));
     }
     return v;
 }
 
-auto contents(ankerl::svector<ThrowOnCopy, 4> const& v) -> std::vector<std::string> {
+template <typename V>
+auto contents(V const& v) -> std::vector<std::string> {
     auto out = std::vector<std::string>();
     for (auto const& e : v) {
         out.push_back(e.value);
@@ -102,34 +188,63 @@ auto contents(ankerl::svector<ThrowOnCopy, 4> const& v) -> std::vector<std::stri
     return out;
 }
 
+using SvCopy = ankerl::svector<ThrowOnCopy, 4>;
+
+/**
+ * @brief Checks what a failed insert at pos still has to be, in every case.
+ *
+ * Nothing in front of pos is ever read or written by an insert, so it has to come out exactly as
+ * it went in, and everything from pos on has to at least be readable -- which is asan's business
+ * rather than the comparison's. The count is either the old one or the full new one: the new
+ * elements are counted in one step each, never half way through one.
+ */
+void require_valid_after_throw(std::vector<std::string> const& before,
+                               std::vector<std::string> const& after,
+                               size_t pos,
+                               size_t count) {
+    REQUIRE((after.size() == before.size() || after.size() == before.size() + count));
+    REQUIRE(after.size() >= pos);
+    for (size_t i = 0; i < pos; ++i) {
+        REQUIRE(after[i] == before[i]);
+    }
+    for (auto const& s : after) {
+        REQUIRE(s.size() <= 40);
+    }
+}
+
 } // namespace
 
-TEST_CASE("insert_count_throwing_copy_keeps_container_intact") {
+TEST_CASE("insert_count_throwing_copy_keeps_container_valid") {
     auto const filler = ThrowOnCopy(std::string(40, 'z'));
 
     // sizes on both sides of the inline capacity, counts that do and do not force a reallocation
     for (size_t size = 0; size <= 9; ++size) {
         for (size_t pos = 0; pos <= size; ++pos) {
             for (size_t count = 1; count <= 5; ++count) {
-                // uninitialized_fill_n destroys whatever it built before rethrowing, so close_gap
-                // sees the same empty gap whichever copy failed. First and last is enough.
-                for (auto const throw_at : {size_t{0}, count - 1}) {
-                    auto v = make(size);
+                // every copy the insert makes is a place the failure can land, and which of them
+                // are into raw slots and which onto live ones depends on all three loops
+                for (size_t throw_at = 0; throw_at < count; ++throw_at) {
+                    auto v = make<SvCopy>(size);
                     auto const before = contents(v);
+                    auto const grows = count > v.capacity() - v.size();
 
                     ThrowOnCopy::budget = static_cast<int>(throw_at);
                     REQUIRE_THROWS_AS(v.insert(v.cbegin() + pos, count, filler), std::runtime_error);
                     ThrowOnCopy::budget = 1000000;
 
-                    // moving cannot throw for this type, so the insert rolls all the way back
-                    REQUIRE(contents(v) == before);
+                    if (grows) {
+                        // built in an allocation of its own, which is simply dropped again
+                        REQUIRE(contents(v) == before);
+                    } else {
+                        require_valid_after_throw(before, contents(v), pos, count);
+                    }
                 }
             }
         }
     }
 }
 
-TEST_CASE("insert_range_throwing_copy_keeps_container_intact") {
+TEST_CASE("insert_range_throwing_copy_keeps_container_valid") {
     auto const source = std::vector<ThrowOnCopy>{
         ThrowOnCopy(std::string(40, 'x')),
         ThrowOnCopy(std::string(40, 'y')),
@@ -138,26 +253,34 @@ TEST_CASE("insert_range_throwing_copy_keeps_container_intact") {
 
     for (size_t size = 0; size <= 9; ++size) {
         for (size_t pos = 0; pos <= size; ++pos) {
-            for (auto const throw_at : {size_t{0}, source.size() - 1}) {
-                auto v = make(size);
+            for (size_t throw_at = 0; throw_at < source.size(); ++throw_at) {
+                auto v = make<SvCopy>(size);
                 auto const before = contents(v);
+                auto const grows = source.size() > v.capacity() - v.size();
 
                 ThrowOnCopy::budget = static_cast<int>(throw_at);
                 REQUIRE_THROWS_AS(v.insert(v.cbegin() + pos, source.begin(), source.end()), std::runtime_error);
                 ThrowOnCopy::budget = 1000000;
 
-                REQUIRE(contents(v) == before);
+                if (grows) {
+                    REQUIRE(contents(v) == before);
+                } else {
+                    require_valid_after_throw(before, contents(v), pos, source.size());
+                }
             }
         }
     }
 }
 
+// A single element goes through emplace(), which copies it into a temporary of its own before the
+// insert starts. The copy is the only part that can fail, and by the time anything has been shifted
+// it is already done, so this one is all or nothing however full the container is.
 TEST_CASE("insert_single_throwing_copy_keeps_container_intact") {
     auto const filler = ThrowOnCopy(std::string(40, 'z'));
 
     for (size_t size = 0; size <= 9; ++size) {
         for (size_t pos = 0; pos <= size; ++pos) {
-            auto v = make(size);
+            auto v = make<SvCopy>(size);
             auto const before = contents(v);
 
             ThrowOnCopy::budget = 0;
@@ -174,7 +297,7 @@ TEST_CASE("emplace_throwing_copy_keeps_container_intact") {
 
     for (size_t size = 1; size <= 9; ++size) {
         for (size_t pos = 0; pos < size; ++pos) { // pos == size goes through emplace_back
-            auto v = make(size);
+            auto v = make<SvCopy>(size);
             auto const before = contents(v);
 
             ThrowOnCopy::budget = 0;
@@ -186,30 +309,112 @@ TEST_CASE("emplace_throwing_copy_keeps_container_intact") {
     }
 }
 
-TEST_CASE("insert_throwing_move_leaves_a_destructible_container") {
-    // Relocating can throw here, so the tail cannot be shifted back and gets dropped instead. The
-    // container is shorter than it was, which the standard allows, but it has to be consistent:
-    // asan and the leak checker are what actually assert that.
+// A type whose move can throw used to be treated worse than one whose move cannot: the rollback
+// could not shift the tail back down, so it dropped it and left the container short. Nothing about
+// the insert depends on what the move constructor promises any more, so this type gets exactly the
+// same treatment as the one above.
+TEST_CASE("insert_throwing_copy_of_a_throwing_move_type_keeps_container_valid") {
+    using Vec = ankerl::svector<ThrowOnCopyAndMove, 4>;
+
     for (size_t size = 0; size <= 9; ++size) {
         for (size_t pos = 0; pos <= size; ++pos) {
             for (size_t count = 1; count <= 3; ++count) {
-                auto v = ankerl::svector<ThrowOnCopyAndMove, 4>();
                 ThrowOnCopyAndMove::budget = 1000000;
-                for (auto& s : make_long_strings(size)) {
-                    v.emplace_back(std::move(s));
-                }
-
+                auto v = make<Vec>(size);
+                auto const before = contents(v);
                 auto const filler = ThrowOnCopyAndMove(std::string(40, 'z'));
+                auto const grows = count > v.capacity() - v.size();
+
                 ThrowOnCopyAndMove::budget = 0;
                 REQUIRE_THROWS_AS(v.insert(v.cbegin() + pos, count, filler), std::runtime_error);
                 ThrowOnCopyAndMove::budget = 1000000;
 
-                REQUIRE(v.size() <= size);
-                // everything still there has to be readable and destroy cleanly
-                for (auto const& e : v) {
-                    REQUIRE(e.value.size() == 40);
+                if (grows) {
+                    REQUIRE(contents(v) == before);
+                } else {
+                    require_valid_after_throw(before, contents(v), pos, count);
                 }
             }
         }
     }
+}
+
+// Growing has to relocate our elements into the new storage, and only there can a move throw. What
+// it leaves behind is spread over the new buffer with a hole in the middle, which no size can
+// describe, and the size of zero it did have meant the destructor walked past all of it. See
+// issue #74, where asan reported the elements moved before the throw as leaked.
+TEST_CASE("insert_throwing_move_while_growing_does_not_leak") {
+    using Vec = ankerl::svector<ThrowOnMove, 4>;
+
+    // filled to the brim, so the insert below has no choice but to grow
+    auto make_full = [](size_t at_least) {
+        ThrowOnMove::budget = 1000000;
+        auto v = make<Vec>(at_least);
+        while (v.size() < v.capacity()) {
+            v.emplace_back(std::string(40, 'q'));
+        }
+        return v;
+    };
+
+    for (size_t at_least = 1; at_least <= 9; ++at_least) {
+        auto const full = make_full(at_least).size();
+        for (size_t pos = 0; pos <= full; ++pos) {
+            // relocating is exactly one move per element, and every one of them is a place the
+            // throw can land: while the front is still a hole, while the tail is going over, and
+            // everywhere in between
+            for (size_t budget = 0; budget < full; ++budget) {
+                auto v = make_full(at_least);
+                auto const filler = ThrowOnMove(std::string(40, 'z'));
+
+                ThrowOnMove::budget = static_cast<int>(budget);
+                REQUIRE_THROWS_AS(v.insert(v.cbegin() + pos, filler), std::runtime_error);
+                ThrowOnMove::budget = 1000000;
+
+                // we never got far enough to adopt the new storage, so our own elements are still
+                // ours and still all there. Some have been moved from, so the count is all that
+                // can be checked here -- that the abandoned storage leaked nothing is asan's job.
+                REQUIRE(v.size() == full);
+            }
+        }
+    }
+}
+
+// The rotation into place is the one step that assigns, so it is the one step a throwing move
+// assignment can interrupt. Everything it touches is a live object either way, so the container
+// stays valid and destructible, just with the elements in an order nobody promised.
+TEST_CASE("insert_throwing_move_assign_leaves_a_valid_container") {
+    using Vec = ankerl::svector<ThrowOnMoveAssign, 8>;
+    auto num_throws = 0;
+
+    // one short of the inline capacity, so the insert stays in place and does rotate
+    for (size_t size = 1; size <= 7; ++size) {
+        for (size_t pos = 0; pos < size; ++pos) {
+            // how many assignments a rotation takes is std::rotate's business, so sweep past it
+            for (size_t budget = 0; budget <= size + 1; ++budget) {
+                ThrowOnMoveAssign::budget = 1000000;
+                auto v = make<Vec>(size);
+                auto const filler = ThrowOnMoveAssign(std::string(40, 'z'));
+
+                ThrowOnMoveAssign::budget = static_cast<int>(budget);
+                try {
+                    v.insert(v.cbegin() + pos, filler);
+                } catch (std::runtime_error const&) {
+                    ++num_throws;
+                }
+                ThrowOnMoveAssign::budget = 1000000;
+
+                // the new element was built and counted before the rotation started, so it is
+                // part of the container whether or not it ever reached pos
+                REQUIRE(v.size() == size + 1);
+
+                // reading every one of them is the actual check, asan is what answers it. Their
+                // values are whatever a half done rotation left, and a moved from string can be
+                // anything valid, so there is nothing to compare against.
+                for (auto const& e : v) {
+                    REQUIRE(e.value.size() <= 40);
+                }
+            }
+        }
+    }
+    REQUIRE(num_throws > 0);
 }


### PR DESCRIPTION
Fixes #74, and removes the family of problems it belongs to.

## The leak

`make_uninitialized_space_new()` relocated the elements into fresh storage in two steps and only recorded the size once both had finished. A move throwing in the second step left whatever the first one had already moved unreachable and unreleased — `target`'s size was still zero, so its destructor freed the allocation without touching them.

## Why the fix is not a `try`/`catch`

That leak was the third of its kind. #68 and this one both came from the same design: making space shifted the elements from `pos` out of the way and immediately counted the resulting hole in `size()`, so until the caller had constructed into it the container was claiming memory that held no elements. Every constructor that could throw then needed a rollback to close the hole again — and the rollback is the part that kept being wrong.

`insert_n()` threads the new elements through the shift instead, the way `std::vector` does: what lands past the old end is constructed, what lands on an element that is still there is assigned over. There is no hole at any point, so nothing has to be undone, and `size()` only ever grows by a step that has already happened. `shift_right()`, `make_uninitialized_space()`, `fill_uninitialized_space()` and `close_gap()` are all gone.

Growing still builds the result in a separate allocation, where the constructed part genuinely is not a prefix, and that one place now spells its cleanup out with a scope guard.

## It is also faster

Assigning rather than destroying and reconstructing lets types reuse their buffer. Instruction counts, gcc 16 -O3, two binaries built from the two headers and run interleaved:

| benchmark | before | after |
|---|---:|---:|
| `fill_front` `int` | 184.1 | **161.3** |
| `fill_front` `std::string` | 27,092 | **21,611** |
| `fill_random` `std::string` | 13,840 | **11,809** |

`std::rotate` was tried for this and is a trap: libstdc++ answers it with a block swapping algorithm, and three moves per swap made `fill_front` on `std::string` twice as expensive. A hand written cycle rotate fixed that and cost `int` 55x, because the shift stops being a `memmove`.

## What it costs

A rollback that was never promised. An insert of **several** elements that has to shift them over live ones can now fail part way and leave the container with the right number of elements but no promise about which — the basic guarantee the standard asks for, and what `std::vector` does. Everything before `pos` is still untouched.

The paths that do not assign over live elements are unaffected:

* growing builds the result in an allocation of its own, so a failed *copy* leaves the original alone. A failed *move* cannot — it has already emptied what it was reading, so our elements are left moved-from and all that survives is that nothing leaks. That is the one guarantee `insert_throwing_move_while_growing_does_not_leak` asserts.
* a single element goes through `emplace()`, which builds it before anything is touched — so `insert(pos, value)` now goes there too, which as a side effect lets it take one of our own elements without copying it aside first

`test/unit/insert_exception_safety.cpp` says which is which, and the element types now throw on copy assignment as well as copy construction, without which half the new paths never see a failure.

## Verification

* 108 test cases / 629,411 assertions green on gcc and clang under ASAN+UBSAN+LSan, and on C++20
* the new `insert_throwing_move_while_growing_does_not_leak` fails with 69,536 bytes leaked in 1,696 allocations when the scope guard is removed


## Known trade: code size

Reviewing this turned up one measured regression I am not fixing here. The shift is now instantiated once per `(direction, placer)` pair, where the old `make_uninitialized_space<D>` was two instantiations shared by every insert form. Base cost for a single insert form is unchanged (9,816 B vs 10,014 B on main), but each *additional* form costs ~8.2 KB instead of ~2.8 KB — 2.1x total `.text` for `std::string` and 4.3x for `int` across six insert forms in one TU.

Dropping the `direction` parameter halves it (string -29%, int -50%) but costs the `int` hot path 5.7%, and two narrower splits measured worse than the status quo. Filed separately rather than churning the diff.
